### PR TITLE
Standardize LNURL name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Logo](media/logo/logo_600.png)
 
-# lnurl-rfc
+# LNURL-rfc
 
-`lnurl` is a bech32-encoded HTTPS query string which is supposed to help payer interact with payee and thus simplify a number of standard scenarios such as requesting incoming channels, withdrawing funds, doing atomic swaps etc.
+`LNURL` is a bech32-encoded HTTPS query string which is supposed to help payer interact with payee and thus simplify a number of standard scenarios such as requesting incoming channels, withdrawing funds, doing atomic swaps etc.

--- a/examples.md
+++ b/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-## lnurl-channel
+## LNURL-channel
 
 ### LNBIG
 https://lnbig.com/
@@ -8,7 +8,7 @@ https://lnbig.com/
 ![LNBIG](media/examples/lnbig.png)
 
 
-## lnurl-withdraw
+## LNURL-withdraw
 
 ### Lightning Gifts
 https://lightning.gifts


### PR DESCRIPTION
set all usage of 'lnurl' to be 'LNURL' for consistency and to improve readability