### PR TITLE
remove "routes", use route hints on invoice instead

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -246,17 +246,6 @@ Note that service will withdraw funds to anyone who can provide a valid ephemera
 	{
 		pr: String, // bech32-serialized lightning invoice
 		successAction: Object, // required. Action to be executed after successfully paying an invoice
-		routes: 
-		[
-			[
-				{
-					nodeId: String,
-					channelUpdate: String // hex-encoded serialized ChannelUpdate gossip message
-				},
-				... // next hop
-			],
-			... // next route
-		] // array with payment routes, should be left empty if no routes are to be provided
 	}
 	```
 	
@@ -267,6 +256,8 @@ Note that service will withdraw funds to anyone who can provide a valid ephemera
 	```
 	
 	`pr` must have the [`h` tag (`description_hash`)](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#tagged-fields) set to `sha256(utf8ByteArray(metadata))`.
+	
+	If `fromnodes` was sent by wallet in the previous step, `pr` should have an [`r` tag (route hints)](https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#tagged-fields) with a reasonable number of routes going from some of the specified `fromnodes` and the final payment destination.
 	
 	`successAction` supports `'url'`, `'message'`, and `'noop'` tags. If there is no action, `{ tag: 'noop' }` must be used. 
 	


### PR DESCRIPTION
So given that `LN WALLET` sent `fromnodes=dd8d3d84886059292845f870c5229f103dd8d7d71d7e9fc6fd52f75a40486d2187` `LN SERVICE` would return an invoice with many full routes like this:

```
{
  "currency": "bc",
  "created_at": 1574450520,
  "expiry": 36000,
  "payee": "02bed1812d3824f7cc4ccd38da5d66a29fcfec146fe95e26cd2e0d3f930d653a8d",
  "msatoshi": 2500,
  "amount_msat": "2500msat",
  "min_final_cltv_expiry": 10,
  "features": "",
  "routes": [
    [
      [
        {
          "pubkey": "dd8d3d84886059292845f870c5229f103dd8d7d71d7e9fc6fd52f75a40486d2187",
          "short_channel_id": "596242x2207x0",
          "fee_base_msat": 1000,
          "fee_proportional_millionths": 1,
          "cltv_expiry_delta": 40
        }
      ],
      [
        {
          "pubkey": "6fd53d84886059292845f870c5229f103dd8d7d71d7e9fc6fd52f75a40486d2187",
          "short_channel_id": "601223x2207x0",
          "fee_base_msat": 1000,
          "fee_proportional_millionths": 1,
          "cltv_expiry_delta": 40
        }
      ],
      [
        {
          "pubkey": "40483d84886059292845f870c5229f103dd8d7d71d7e9fc6fd52f75a40486d2187",
          "short_channel_id": "568245x2207x0",
          "fee_base_msat": 1000,
          "fee_proportional_millionths": 1,
          "cltv_expiry_delta": 40
        }
      ]
    ],
    [
      [
        {
          "pubkey": "dd8d3d84886059292845f870c5229f103dd8d7d71d7e9fc6fd52f75a40486d2187",
          "short_channel_id": "522145x2207x0",
          "fee_base_msat": 1000,
          "fee_proportional_millionths": 1,
          "cltv_expiry_delta": 40
        }
      ],
      [
        {
          "pubkey": "7f103d84886059292845f870c5229f103dd8d7d71d7e9fc6fd52f75a40486d2187",
          "short_channel_id": "600000x2207x0",
          "fee_base_msat": 1000,
          "fee_proportional_millionths": 1,
          "cltv_expiry_delta": 40
        }
      ],
      [
        {
          "pubkey": "92923d84886059292845f870c5229f103dd8d7d71d7e9fc6fd52f75a40486d2187",
          "short_channel_id": "593545x2207x0",
          "fee_base_msat": 1000,
          "fee_proportional_millionths": 1,
          "cltv_expiry_delta": 40
        }
      ]
    ]
  ],
  "payment_hash": "13c034cb0aed72c0a2ee54c5678bd13b0bf64017fddd3dd6825205df4c17c6e0",
  "signature": "3044022069e467ff258325c25f59ba7448e466441bb30fe6040f03fc77181672f106ca780220617525cbee5ebb5b9f5ee8f87a8b66c2ddae2ab063b1999b0747ab3df862242e"
}
```

And every wallet already knows how to parse and handle this (or they should at least).