### PR TITLE
Add an optional thumbnail to lnurl-pay

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -212,12 +212,12 @@ Note that service will withdraw funds to anyone who can provide a valid ephemera
     {"status":"ERROR", "reason":"error details..."}
     ```
     
-    `metadata` should contain the following json:
+    `metadata` json array must contain one `text/plain` entry, all other types of entries are optional:
     
     ```
     [
         [
-            "text/plain", // mime-type, "text/plain" must always be present
+            "text/plain", // must always be present
             content // actual metadata content
         ],
         [
@@ -225,7 +225,7 @@ Note that service will withdraw funds to anyone who can provide a valid ephemera
             content // base64 string
         ],
         [
-            "image/jpg;base64", // optional 512x512px JPG thumbnail which will represent this lnurl in a list or grid
+            "image/jpeg;base64", // optional 512x512px JPG thumbnail which will represent this lnurl in a list or grid
             content // base64 string
         ],
         ... // more objects for future types

--- a/spec.md
+++ b/spec.md
@@ -222,11 +222,11 @@ Note that service will withdraw funds to anyone who can provide a valid ephemera
         ],
         [
             "image/png;base64", // optional 512x512px PNG thumbnail which will represent this lnurl in a list or grid
-            content // base64 string
+            content // base64 string, up to 136536 characters (100Kb of image data in base-64 encoding)
         ],
         [
             "image/jpeg;base64", // optional 512x512px JPG thumbnail which will represent this lnurl in a list or grid
-            content // base64 string
+            content // base64 string, up to 136536 characters (100Kb of image data in base-64 encoding)
         ],
         ... // more objects for future types
     ]

--- a/spec.md
+++ b/spec.md
@@ -203,7 +203,6 @@ Note that service will withdraw funds to anyone who can provide a valid ephemera
         maxSendable: MilliSatoshi, // max amount LN SERVICE is willing to receive
         minSendable: MilliSatoshi, // min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
         metadata: String, // metadata json which must be presented as raw string here, this is required to pass signature verification at a later step
-        thumbnail: String or null // optional URL to 512x512px thumbnail which will represent this lnurl in a list or grid, domain here must be the same as `callback` domain
         tag: "payRequest" // type of LNURL
     }
     ```
@@ -213,13 +212,21 @@ Note that service will withdraw funds to anyone who can provide a valid ephemera
     {"status":"ERROR", "reason":"error details..."}
     ```
     
-    `metadata` must contain the following json:
+    `metadata` should contain the following json:
     
     ```
     [
         [
-            "text/plain", // mime-type, "text/plain" is the only supported type for now, must always be present
+            "text/plain", // mime-type, "text/plain" must always be present
             content // actual metadata content
+        ],
+        [
+            "image/png;base64", // optional 512x512px PNG thumbnail which will represent this lnurl in a list or grid
+            content // base64 string
+        ],
+        [
+            "image/jpg;base64", // optional 512x512px JPG thumbnail which will represent this lnurl in a list or grid
+            content // base64 string
         ],
         ... // more objects for future types
     ]

--- a/spec.md
+++ b/spec.md
@@ -203,6 +203,7 @@ Note that service will withdraw funds to anyone who can provide a valid ephemera
         maxSendable: MilliSatoshi, // max amount LN SERVICE is willing to receive
         minSendable: MilliSatoshi, // min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
         metadata: String, // metadata json which must be presented as raw string here, this is required to pass signature verification at a later step
+        thumbnail: String or null // optional URL to 512x512px thumbnail which will represent this lnurl in a list or grid, domain here must be the same as `callback` domain
         tag: "payRequest" // type of LNURL
     }
     ```


### PR DESCRIPTION
In preparation for storing `lnurl-pay` in a wallet I thought it would be nice to display them in a grid where each will have its own thumbnail. Since thumbnail is optional wallet would also have to come up with a way to display `lnurl-pay` without thumbnails, but that's outside of this spec.