### PR TITLE
LUD-18 as a pay-back scheme

### DIFF
--- a/18.md
+++ b/18.md
@@ -21,6 +21,7 @@ JSON array may contain one or more records of the following forms:
 3. `[ "application/lnurl-auth", hex(<linkingKey>), hex(sign(utf8ToBytes(<k1>), <linkingPrivKey>)) ]`
 4. `[ "text/identifier", <internet identifier> ]`
 5. `[ "text/email", <email address> ]`
+6. `[ "text/pay-back-option", <lightning invoice | lnurl-pay | email-like lightning address | ...> ]`
 
 If present, JSON array MAY NOT contain more than one record with the same metadata type.
 
@@ -42,6 +43,16 @@ If `LN SERVICE` wants to get one or more types of payer identities from `LN WALL
     ],
     [ "text/identifier" ],
     [ "text/email" ],
+    [ 
+      "application/pay-back-option",
+      isMandatory,
+      [ "text/pay-back-invoice",
+        minDuration // minimum time period for which the received invoice must be valid
+      ],
+      [ "text/pay-back-lnurlp" ],
+      [ "text/pay-back-lightning-address" ],
+      ...,
+    ]
     ...,
   ],
 ]


### PR DESCRIPTION
I believe that LNURL-pay should provide a way for the service to pay back some change to the user.
The use case is for stuff that the price can't be known beforehand, like a gas pump, rental equipment...
The user pre-pay what should be a reasonable amount, a little bit more than average, and receive a change back at the end.
Somewhat related to what I commented here:
https://github.com/fiatjaf/lnurl-rfc/pull/49#issuecomment-826336746
Therefore, this LUD-18 come in handy, as the user identifies himself in a useful way, providing a way to receive the change.