### PR TITLE
Remove ambiquity in lud-20

### DIFF
--- a/20.md
+++ b/20.md
@@ -12,4 +12,4 @@ LUD-20: Long payment description for pay protocol.
 `WALLET` MUST upon recognizing the `text/long-desc` metadata use it as the payment description in the pay screen.
 `WALLET` MAY display the `text/long-desc` text together with the `text/plain` text.
 
-If `text/long-desc` is not included in the metadata payload,`text/plain` SHOULD instead be used on the pay screen.
+If `text/long-desc` is not included in the metadata payload,`text/plain` MUST instead be used on the pay screen.


### PR DESCRIPTION
This PR just changes one word. "MUST" instead of "SHOULD".
In my opinion SHOULD directly conflicts with lud-6.

In lud-6 WALLET is REQUIRED to show "text/plain".
lud-20 now says if the long description is not provided you should include "text/plain". But it would also be allowed to not show it.
Basically this means that a SERVICE that has not implement lud-20 but has implemented lud-6 cannot be sure his description makes it to a wallet that has implemented lud-20