### PR TITLE
More explicit lud-16

### DIFF
--- a/16.md
+++ b/16.md
@@ -7,13 +7,13 @@ LUD-16: Paying to static internet identifiers.
 
 ## Paying to [internet identifiers](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1) (email-like addresses)
 
-The idea here is that a `SERVICE` can offer human-readable addresses for users or specific internal endpoints that use the format `<username>@<domainname>`, e.g. satoshi@bitcoin.org. A user can then type these on a `WALLET`. The `<username>` is limited to `a-z0-9-_.`.
+The idea here is that a `SERVICE` can offer human-readable addresses for users or specific internal endpoints that use the format `<username>@<domainname>`, e.g. satoshi@bitcoin.org. A user can then type these on a `WALLET`. The `<username>` is limited to `a-z0-9-_.`. Please note that this is way more strict than common email addresses as it allows less symbols and only lowercase characters.
 
 Upon seeing such an address, `WALLET` makes a GET request to `https://<domain>/.well-known/lnurlp/<username>` endpoint if `domain` is clearnet or `http://<domain>/.well-known/lnurlp/<username>` if `domain` is onion. For example, if the address is `satoshi@bitcoin.org`, the request is to be made to `https://bitcoin.org/.well-known/lnurlp/satoshi`.
 
-The response from `SERVICE` then must be the same as in [LUD-06](06.md), step 3, and the flow is the same.
+The response from `SERVICE` then MUST be the same as in [LUD-06](06.md), step 3, and the flow is the same. If `SERVICE` cannot find the requested `<username>` it MUST return an Error in this response.
 
-If providing such a scheme, `SERVICE` must add to the `metadata` JSON array either a `text/email` entry or a `text/identifier` entry, as in examples below:
+If providing such a scheme, `SERVICE` MUST add to the `metadata` JSON array either a `text/email` entry or a `text/identifier` entry, as in examples below:
 
 ```
 [
@@ -31,4 +31,4 @@ or
 ]
 ```
 
-The `text/email` entry must be used if the internet identifier corresponds to an actual email address.
+The `text/email` entry MUST be used if the internet identifier corresponds to an actual email address.


### PR DESCRIPTION
This PR tries to make lud-16 more explicit and leave less open questions.

Until now the PR linked to the static internet identifier spec, but at the same time defined rules for the <username> that are not part of the internet identifier spec. This is okay, but I think it is good to make this really clear, that the username spec is more strict than the common internet identifier spec. That's why I added a sentence there.

Further more I added that if the SERVICE does not find the identifier, it MUST throw an error. I added this because already in first tests I could see SERVICES implement it differently, one throws an error, the other doesn't.

And lastly I capitalized some MUSTS