### PR TITLE
Lud-1: clarify case sensitivity

### DIFF
--- a/01.md
+++ b/01.md
@@ -7,6 +7,8 @@ LUD-01: Base LNURL encoding and decoding
 
 `LNURL` is a [bech32](https://bips.xyz/173#bech32)-encoded HTTPS/Onion URL that can be interacted with automatically by a `WALLET` in a standard way such that a `SERVICE` can provide extra services or better experience for the user.
 
+Bech32-encoded `LNURL`s can both be uppercase or lowercase, but not mixed case. When used in QR-Codes they SHOULD be uppercase.
+
 An example `LNURL`:
 > `https://service.com/api?q=3fc3645b439ce8e7f2553a69e5267081d96dcd340693afabe04be7b0ccd178df`
 


### PR DESCRIPTION
In lud-1 the encoded LNURL is always displayed in UPPERCASE, but it is nowhere mentioned if this is required. This can lead to some people assuming UPPERCASE is mandatory.
I understand that for QR codes this makes sense, but for non QR codes the normal bech32 encoding is lowercase.

If someone checks for the fallback scheme and tests against "lightning=LNURL1" and a SERVICE created the fallback by using "lightning=lnurl1" it might actually not be recognized if it wasn't programmed in a case insensitive way.

I would suggest to allow both, uppercase and lowercase.
What do you think?