### PR TITLE
Lud-6 clarification

### DIFF
--- a/06.md
+++ b/06.md
@@ -31,8 +31,7 @@ LUD-06: `payRequest` base spec.
     `metadata` json array must contain one `text/plain` entry, all other types of entries are optional.
     `metadata` json array must contain either one `image/png;base64` entry or one `image/jpeg;base64` entry or neither.
 
-    The first item of an array inside the `metadata` array is always a string representing the metadata type.
-    Any array item that follows can be of any JSON type. Implementors should NOT assume it will always be a string.
+    The `metadata` json array is only allowed to contain arrays. The first item of an array inside the `metadata` array is always a string representing the metadata type while any item that follows can be of any JSON type. Implementors MUST NOT assume it will always be a string.
 
     ```
     [
@@ -99,7 +98,7 @@ LUD-06: `payRequest` base spec.
 	```
 
 6. `LN WALLET` Verifies that `h` tag in provided invoice is a hash of `metadata` string converted to byte array in UTF-8 encoding.
-7. `LN WALLET` Verifies that amount in provided invoice equals an amount previously specified by user.
+7. `LN WALLET` Verifies that amount in provided invoice equals the amount previously specified by user.
 10. `LN WALLET` pays the invoice, no additional user confirmation is required at this point.
 11. Once payment is fulfilled `LN WALLET` executes a non-null `successAction`. For `message`, a toaster or popup is sufficient. For `url`, the wallet should give the user a popup which displays `description`, `url`, and a 'open' button to open the `url` in a new browser tab. For `aes`, `LN WALLET` must attempt to decrypt a `ciphertext` with payment preimage. `LN WALLET` should also store `successAction` data on the transaction record.
 


### PR DESCRIPTION
This is my suggestion for lud-6 clarification.

It tries to clarify the metadata array like discussed in #108.
Please note that I also changed the wording to: Implementors MUST NOT assume... instead of "should NOT" as should would say they still follow the spec while having it break with some implementations.

Furthermore it changes a word in step 7