### PR TITLE
Change example JSON responses to use Typescript types

### DIFF
--- a/02.md
+++ b/02.md
@@ -15,12 +15,12 @@ Suppose user has a balance on a certain service which he wishes to turn into an 
 2. `LN WALLET` makes a GET request to `LN SERVICE` using the decoded LNURL.
 3. `LN WALLET` gets JSON response from `LN SERVICE` of form:
 
-	```
+	```Typescript
 	{
-		uri: String, // Remote node address of form node_key@ip_address:port_number
-		callback: String, // a second-level URL which would initiate an OpenChannel message from target LN node
-		k1: String, // random or non-random string to identify the user's LN WALLET when using the callback URL
-		tag: "channelRequest" // type of LNURL
+		"uri": string, // Remote node address of form node_key@ip_address:port_number
+		"callback": string, // a second-level URL which would initiate an OpenChannel message from target LN node
+		"k1": string, // random or non-random string to identify the user's LN WALLET when using the callback URL
+		"tag": "channelRequest" // type of LNURL
 	}
 	```
 	or

--- a/03.md
+++ b/03.md
@@ -14,19 +14,19 @@ Today users are asked to provide a withdrawal Lightning invoice to a service. Th
 1. User scans a LNURL QR code or accesses an `lightning:LNURL..` link with `LN WALLET` and `LN WALLET` decodes LNURL.
 2. `LN WALLET` makes a GET request to `LN SERVICE` using the decoded LNURL.
 3. `LN WALLET` gets JSON response from `LN SERVICE` of form:
-    ```
+    ```Typescript
     {
-        tag: "withdrawRequest", // type of LNURL
-        callback: String, // The URL which LN SERVICE would accept a withdrawal Lightning invoice as query parameter
-        k1: String, // Random or non-random string to identify the user's LN WALLET when using the callback URL
-        defaultDescription: String, // A default withdrawal invoice description
-        minWithdrawable: Integer, // Min amount (in millisatoshis) the user can withdraw from LN SERVICE, or 0
-        maxWithdrawable: Integer, // Max amount (in millisatoshis) the user can withdraw from LN SERVICE, or equal to minWithdrawable if the user has no choice over the amounts
+        "tag": "withdrawRequest", // type of LNURL
+        "callback": string, // The URL which LN SERVICE would accept a withdrawal Lightning invoice as query parameter
+        "k1": string, // Random or non-random string to identify the user's LN WALLET when using the callback URL
+        "defaultDescription": string, // A default withdrawal invoice description
+        "minWithdrawable": number, // Min amount (in millisatoshis) the user can withdraw from LN SERVICE, or 0
+        "maxWithdrawable": number, // Max amount (in millisatoshis) the user can withdraw from LN SERVICE, or equal to minWithdrawable if the user has no choice over the amounts
     }
     ```
     or
 
-    ```
+    ```JSON
     {"status": "ERROR", "reason": "error details..."}
     ```
 4. `LN WALLET` Displays a withdraw dialog where user can specify an exact sum to be withdrawn which would be bounded by:

--- a/04.md
+++ b/04.md
@@ -34,14 +34,12 @@ Later, once `LN SERVICE` receives a call at the specified `LNURL-auth` handler, 
 2. `LN WALLET` displays a "Login" dialog which must include a domain name extracted from `LNURL` query string and `action` enum translated into human readable text if `action` query parameter was present.
 3. Once accepted by user, `LN WALLET` signs `k1` on `secp256k1` using `linkingPrivKey` and DER-encodes the signature. `LN WALLET` Then issues a GET to `LN SERVICE` using `<LNURL_hostname_and_path>?<LNURL_existing_query_parameters>&sig=<hex(sign(hexToBytes(k1), linkingPrivKey))>&key=<hex(linkingKey)>`
 4. `LN SERVICE` responds with the following JSON once client signature is verified:
-    ```
-    {
-        status: "OK"
-    }
+    ```JSON
+    {"status": "OK"}
     ```
     or
 
-    ```
+    ```JSON
     {"status": "ERROR", "reason": "error details..."}
     ```
 

--- a/06.md
+++ b/06.md
@@ -17,18 +17,18 @@ Then, once the user accepts the terms (and choose an amount, if that is not fixe
 2. `LN WALLET` makes a GET request to `LN SERVICE` using the decoded LNURL.
 3. `LN WALLET` gets JSON response from `LN SERVICE` of form:
 
-    ```
+    ```Typescript
     {
-        callback: String, // The URL from LN SERVICE which will accept the pay request parameters
-        maxSendable: MilliSatoshi, // Max amount LN SERVICE is willing to receive
-        minSendable: MilliSatoshi, // Min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
-        metadata: String, // Metadata json which must be presented as raw string here, this is required to pass signature verification at a later step
-        tag: "payRequest" // Type of LNURL
+        "callback": string, // The URL from LN SERVICE which will accept the pay request parameters
+        "maxSendable": number, // Max millisatoshi amount LN SERVICE is willing to receive
+        "minSendable": number, // Min millisatoshi amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
+        "metadata": string, // Metadata json which must be presented as raw string here, this is required to pass signature verification at a later step
+        "tag": "payRequest" // Type of LNURL
     }
     ```
     or
 
-    ```
+    ```JSON
     {"status": "ERROR", "reason": "error details..."}
     ```
 
@@ -37,31 +37,35 @@ Then, once the user accepts the terms (and choose an amount, if that is not fixe
 
     The `metadata` json array is only allowed to contain arrays. The first item of an array inside the `metadata` array is always a string representing the metadata type while any item that follows can be of any JSON type. Implementors MUST NOT assume it will always be a string.
 
-    ```
+    ```Typescript
     [
         [
-            "text/plain", // mandatory, short description displayed when paying and in transaction log
-            content // actual metadata content
+            "text/plain", // mandatory,
+            string // short description displayed when paying and in transaction log
         ],
         [
-            "text/long-desc", // optional longer description of the payment, MAY contain newlines
-            content // actual metadata content
+            "text/long-desc", // optional
+            string // longer description of the payment, MAY contain newlines
         ],
         [
-            "image/png;base64", // optional 512x512px PNG thumbnail which will represent this lnurl in a list or grid
-            content // base64 string, up to 136536 characters (100Kb of image data in base-64 encoding)
+            "image/png;base64",
+            string // base64 string, optional 512x512px PNG thumbnail which will represent this lnurl in a list or grid. Up to 136536 characters (100Kb of image data in base-64 encoding)
         ],
         [
-            "image/jpeg;base64", // optional 512x512px JPG thumbnail which will represent this lnurl in a list or grid
-            content // base64 string, up to 136536 characters (100Kb of image data in base-64 encoding)
+            "image/jpeg;base64", // optional
+            string // base64 string, 512x512px JPG thumbnail which will represent this lnurl in a list or grid. Up to 136536 characters (100Kb of image data in base-64 encoding)
         ],
-        ... // more objects for future types
+        // future entries:
+        [
+            string,
+            any
+        ]
     ]
     ```
 
     and be sent as a string:
 
-    ```
+    ```JSON
     "[[\"text/plain\", \"lorem ipsum blah blah\"]]"
     ```
 
@@ -88,16 +92,16 @@ Then, once the user accepts the terms (and choose an amount, if that is not fixe
 
 5. `LN Service` takes the GET request and returns JSON response of form:
 
-	```
+	```Typescript
 	{
-		pr: String, // bech32-serialized lightning invoice
-		routes: [], // an empty array
+		pr: string, // bech32-serialized lightning invoice
+		routes: [] // an empty array
 	}
 	```
 
 	or
 
-	```
+	```JSON
 	{"status":"ERROR", "reason":"error details..."}
 	```
 

--- a/07.md
+++ b/07.md
@@ -13,17 +13,17 @@ LUD-07: `hostedChannelRequest` base spec.
 2. `LN WALLET` makes a GET request to `LN SERVICE` using the decoded LNURL.
 3. `LN WALLET` gets JSON response from `LN SERVICE` of form:
 
-    ```
+    ```Typescript
     {
-    	uri: String, // Remote node address of form node_key@ip_address:port_number
-    	k1: String, // a second-level hex encoded secret byte array to be used by wallet in `InvokeHostedChannel` message, may be random if Host has no use for it
-    	alias: String, // Optional remote node alias
-    	tag: "hostedChannelRequest" // type of LNURL
+    	"uri": string, // Remote node address of form node_key@ip_address:port_number
+    	"k1": string, // a second-level hex encoded secret byte array to be used by wallet in `InvokeHostedChannel` message, may be random if Host has no use for it
+    	"alias": string, // Optional remote node alias
+    	"tag": "hostedChannelRequest" // type of LNURL
     }
     ```
     or
 
-    ```
+    ```JSON
     {"status": "ERROR", "reason": "error details..."}
     ```
 4. `LN WALLET` opens a connection to the target node using `uri` field.

--- a/09.md
+++ b/09.md
@@ -15,35 +15,35 @@ To implement this, a `SERVICE` must alter its JSON response to the second callba
 
 ```diff
  {
- 	pr: String,
- 	routes: [],
-+   successAction: Object,
+ 	"pr": string,
+ 	"routes": [],
++   "successAction": Object
  }
 ```
 
 In which Object has the format:
 
-```
+```Typescript
 {
-   tag: String, // action type
+   tag: string, // action type
    ...rest of fields depends on tag value
 }
 ```
 
 This document defines the _message_ and the _url_ types. See examples:
 
-```
+```JSON
 {
-  tag: 'message',
-  message: 'Thank you for using bike-over-ln co! Your rental bike is unlocked now' // Up to 144 characters
+  "tag": "message",
+  "message": "Thank you for using bike-over-ln co! Your rental bike is unlocked now" // Up to 144 characters
 }
 ```
 
-```
+```JSON
 {
-   tag: 'url'
-   description: 'Thank you for your purchase. Here is your order details' // Up to 144 characters
-   url: 'https://www.ln-service.com/order/<orderId>' // url domain must be the same as `callback` domain at step 3
+   "tag": "url",
+   "description": "Thank you for your purchase. Here is your order details", // Up to 144 characters
+   "url": "https://www.ln-service.com/order/<orderId>" // url domain must be the same as `callback` domain at step 3
 }
 ```
 

--- a/10.md
+++ b/10.md
@@ -13,12 +13,12 @@ The encryption key is the payment preimage for the invoice specified in the `pr`
 
 See example below:
 
-```
+```Typescript
 {
-   tag: 'aes'
-   description: 'Here is your redeem code' // Up to 144 characters
-   ciphertext: <base64> // an AES-encrypted data where encryption key is payment preimage, up to 4kb of characters
-   iv: <base64> // initialization vector, exactly 24 characters
+   "tag": "aes",
+   "description": "Here is your redeem code", // Up to 144 characters
+   "ciphertext": string, // base64, AES-encrypted data where encryption key is payment preimage, up to 4kb of characters
+   "iv": string // base64, initialization vector, exactly 24 characters
 }
 ```
 

--- a/11.md
+++ b/11.md
@@ -11,9 +11,9 @@ This document defines a `disposable` field that may be returned by `SERVICE` alo
 
 ```diff
  {
- 	pr: String,
- 	routes: [],
-+   disposable: Boolean,
+ 	"pr": string,
+ 	"routes": [],
++   "disposable": boolean
  }
 ```
 

--- a/12.md
+++ b/12.md
@@ -17,12 +17,12 @@ This is completely additional/ad-hoc, so current implementations are not affecte
 
 ```diff
  {
-   callback: String,
-   maxSendable: MilliSatoshi,
-   minSendable: MilliSatoshi,
-   metadata: String,
-+  commentAllowed: Number,
-   tag: "payRequest",
+   "callback": string,
+   "maxSendable": number,
+   "minSendable": number,
+   "metadata": string,
++  "commentAllowed": number,
+   "tag": "payRequest"
  }
 ```
 

--- a/14.md
+++ b/14.md
@@ -19,13 +19,13 @@ The callback JSON response is modified as such:
 
 ```diff
  {
-   tag: "withdrawRequest",
-   callback: String,
-   k1: String,
-   defaultDescription: String,
-   minWithdrawable: Integer,
-   maxWithdrawable: Integer,
-+  balanceCheck: String
+   "tag": "withdrawRequest",
+   "callback": string,
+   "k1": string,
+   "defaultDescription": string,
+   "minWithdrawable": number,
+   "maxWithdrawable": number,
++  "balanceCheck": string
  }
 ```
 

--- a/18.md
+++ b/18.md
@@ -15,22 +15,22 @@ If `SERVICE` wants to get one or more types of payer identities from `WALLET` th
 
 ```diff
  {
-   callback: String,
-   maxSendable: MilliSatoshi,
-   minSendable: MilliSatoshi,
-   metadata: String,
-+  payerData: {
-+    "name": { "mandatory": Boolean },
-+    "pubkey": { "mandatory": Boolean },
-+    "identifier": { "mandatory": Boolean },
-+    "email": { "mandatory": Boolean },
+   "callback": String,
+   "maxSendable": number,
+   "minSendable": number,
+   "metadata": string,
++  "payerData": {
++    "name": { "mandatory": boolean },
++    "pubkey": { "mandatory": boolean },
++    "identifier": { "mandatory": boolean },
++    "email": { "mandatory": boolean },
 +    "auth": {
-+       "mandatory": Boolean,
-+       "k1": String // hex encoded 32 bytes of challenge
++       "mandatory": boolean,
++       "k1": string // hex encoded 32 bytes of challenge
 +    ],
 +    ...other fields may be negotiated
 +  },
-   tag: "payRequest",
+   "tag": "payRequest",
  }
 ```
 
@@ -38,7 +38,7 @@ Notice that just including the payer id kind ("name", "pubkey" etc.) in the `pay
 
 ## 2. Specifying payer identity before sending a payment
 
-In response to seeing a `payerData` record in initial response from `SERVICE`, `WALLET` attaches a `payerdata` query parameter to LNURL-PAY callback with value set to a JSON object:
+In response to seeing a `payerData` record in the initial response from `SERVICE`, `WALLET` attaches a `payerdata` query parameter to LNURL-PAY callback with value set to a JSON object:
 
 ```diff
 - <callback><?|&>amount=<milliSatoshi>
@@ -47,17 +47,17 @@ In response to seeing a `payerData` record in initial response from `SERVICE`, `
 
 The JSON object MUST be of the following format (notice that these fields are shown only for completion, in practice it will likely contain just a subset of these):
 
-```
+```Typescript
 {
-  "name": <free form string>,
-  "pubkey": hex(<randomly generated secp256k1 pubkey>),
+  "name": string, // free form string
+  "pubkey": string, // hex(<randomly generated secp256k1 pubkey>),
   "auth": {
-    "key": hex(<linkingKey>),
-    "k1": String, // same as received from service on section 1
-    "sig": hex(sign(hexToBytes(<k1>), <linkingPrivKey>)) // following LUD-04
+    "key": string, // hex(<linkingKey>)
+    "k1": string, // same as received from service on section 1
+    "sig": string, // following LUD-04: hex(sign(hexToBytes(<k1>), <linkingPrivKey>))
   },
-  "email": <email address>,
-  "identifier": <internet identifier>,
+  "email": string,
+  "identifier": string,
   ...other fields may be included if supported by wallet and requested by service
 }
 ```

--- a/19.md
+++ b/19.md
@@ -15,14 +15,14 @@ Modification required in `SERVICE` callback JSON of LNURL-withdraw:
 
 ```diff
  {
-   tag: "withdrawRequest",
-   callback: String,
-   k1: String,
-   defaultDescription: String,
-   minWithdrawable: Integer,
-   maxWithdrawable: Integer,
-   balanceCheck: String,
-+  payLink: String,
+   "tag": "withdrawRequest",
+   "callback": string,
+   "k1": string,
+   "defaultDescription": string,
+   "minWithdrawable": number,
+   "maxWithdrawable": number,
+   "balanceCheck": string,
++  "payLink": string
  }
 ```
 


### PR DESCRIPTION
This pull request attempts to clear out inconsistencies with the JSON examples in the LUDs.

Types such as `MilliSatoshi` has been changed to `number` to clear up any confusions regarding what a value is supposed to be. Context-important information has been moved to a comment on the same line instead.

The rationale behind Typescript types being used is because it's the closest to Javascript, which in turn is the closest to JSON.

The keys in the examples has been changed to be an actual string, as is required to be valid JSON.

Not sure if this is a worthwhile improvement or an actual improvement at all, but it at least brings some consistency.