### PR TITLE
LUD-03: Add mermaid.js diagram to withdrawRequest

### DIFF
--- a/03.md
+++ b/03.md
@@ -2,6 +2,7 @@ LUD-03: `withdrawRequest` base spec.
 ====================================
 
 `author: akumaigorodski`
+`diagram: johnpaulkiser`
 
 ---
 
@@ -10,6 +11,46 @@ LUD-03: `withdrawRequest` base spec.
 Today users are asked to provide a withdrawal Lightning invoice to a service. This requires some effort and is especially painful when users try to withdraw funds into mobile wallets while using a desktop website. Instead of asking for Lightning invoice a service could display a "withdraw" QR code which contains a specialized `LNURL`.
 
 ### Wallet to service interaction flow:
+
+```mermaid
+sequenceDiagram
+	actor Alice
+    	participant Wallet
+    	participant LN Service
+    	Alice->>LN Service: initiates LNURL withdrawRequest
+	Note over LN Service: displays <br/>encoded LNURL
+    	Wallet->>LN Service: Scans QR or copies encoded LNURL
+	Note over Wallet: decodes LNURL
+    	Wallet->>LN Service: makes GET to LNURL
+    	alt Success
+    		LN Service--)Wallet: returns  JSON response
+    		Note left of LN Service: {<br/>"callback": string, <br /> "k1": string, <br/> "minWithdrawable": number, <br/> "maxWithdrawable": number, <br/> ...<br/>}
+    		Wallet->>Alice: display withdrawal dialog
+    		Alice->>Wallet: specify exact withdrawal amount
+    		Note over Wallet: creates BOLT-11 invoice
+    		Wallet->>LN Service: makes GET to: callback URL with query params k1 & pr=<BOLT-11 invoice>
+		alt Success
+    			LN Service--)Wallet: returns  JSON response
+			Note left of LN Service: {"status": "OK"}
+			Wallet--)Wallet: waits for payment
+			Wallet->>Alice: notifies of successful withdrawal
+			Note over Alice: END
+		else Failure
+			LN Service--)Wallet: returns  JSON response
+                     	Note left of LN Service: {<br/>"status": "ERROR", <br /> "reason": string <br/> }
+                        Wallet->>Alice: notifies of unsuccessful withdrawal
+			Note over Alice: END
+		end
+	else Failure
+    		LN Service--)Wallet: returns JSON response
+    		Note left of LN Service: {<br/>"status": "ERROR", <br /> "reason": string <br/> }
+    		Wallet->>Alice: notifies of unsuccessful withdrawal
+    		Note over Alice: END
+	end 
+
+
+
+```
 
 1. User scans a LNURL QR code or accesses an `lightning:LNURL..` link with `LN WALLET` and `LN WALLET` decodes LNURL.
 2. `LN WALLET` makes a GET request to `LN SERVICE` using the decoded LNURL.


### PR DESCRIPTION
I saw someone asking for this on twitter and thought I would write it up really quick. I can do this for the rest of the spec if there is interest in such things. 

> Note: I took the liberty of splitting up the Wallet & User (Alice) into separate entities because I've seen many cases of wallets not handling the user flow very well. (ie. Muun not allowing users to specify a withdrawal amount 😠 )