### PR TITLE
Remove the 512x512 size in the image specification

### DIFF
--- a/06.md
+++ b/06.md
@@ -49,11 +49,11 @@ Then, once the user accepts the terms (and choose an amount, if that is not fixe
         ],
         [
             "image/png;base64", // optional
-            string // base64 string, optional 512x512px PNG thumbnail which will represent this lnurl in a list or grid. Up to 136536 characters (100Kb of image data in base-64 encoding)
+            string // base64 string, optional PNG thumbnail which will represent this lnurl in a list or grid. Up to 136536 characters (100Kb of image data in base-64 encoding).
         ],
         [
             "image/jpeg;base64", // optional
-            string // base64 string, 512x512px JPG thumbnail which will represent this lnurl in a list or grid. Up to 136536 characters (100Kb of image data in base-64 encoding)
+            string // base64 string, optional JPG thumbnail which will represent this lnurl in a list or grid. Up to 136536 characters (100Kb of image data in base-64 encoding).
         ],
         // future entries:
         [


### PR DESCRIPTION
Remove the 512x512 size in the image specification as it read like a requirement.

Specification is a 100kb byte limit, 512x512 will most of the time be larger than this.