### PR TITLE
Support multiple profiles for LUD-05

### DIFF
--- a/05.md
+++ b/05.md
@@ -11,13 +11,16 @@ LUD-05: BIP32-based seed generation for auth protocol.
 2. `LN SERVICE` full domain name is extracted from login `LNURL` and then hashed using `hmacSha256(hashingKey, full service domain name)`. Full domain name here means FQDN with last full-stop (aka "point") omitted (Example: for `https://x.y.z.com/...` it would be `x.y.z.com`).
 3. First 16 bytes are taken from resulting hash and then turned into a sequence of 4 `Long` values which are in turn used to derive a service-specific `linkingKey` using `m/138'/<long1>/<long2>/<long3>/<long4>` path, a Scala example:
 
+If you want to support multiple profiles, you can use a `profileIndex` in the hashing key derivation path: `m/138'/<profileIndex>`, incrementing the counter for each new profile.
+
 ```Scala
 import fr.acinq.bitcoin.crypto
 import fr.acinq.bitcoin.Protocol
 import java.io.ByteArrayInputStream
 import fr.acinq.bitcoin.DeterministicWallet._
 val domainName = "site.com"
-val hashingPrivKey = derivePrivateKey(walletMasterKey, hardened(138L) :: 0L :: Nil)
+val profileIndex = 0L
+val hashingPrivKey = derivePrivateKey(walletMasterKey, hardened(138L) :: profileIndex :: Nil)
 val derivationMaterial = hmac256(key = hashingPrivKey.toBin, message = domainName)
 val stream = new ByteArrayInputStream(derivationMaterial.slice(0, 16).toArray)
 val pathSuffix = Vector.fill(4)(Protocol.uint32(stream, ByteOrder.BIG_ENDIAN)) // each uint32 call consumes next 4 bytes


### PR DESCRIPTION
If a wallet wants to support multiple profiles to authenticate for, instead of having to generate a new seed for every profile, they can just increment this index.