### PR TITLE
Fix invalid test vector in LUD-05

### DIFF
--- a/05.md
+++ b/05.md
@@ -29,6 +29,6 @@ val linkingPubKey = linkingPrivKey.publicKey
 
 ```
 domain name: site.com
-hashingPrivKey: 0x7d417a6a5e9a6a4a879aeaba11a11838764c8fa2b959c242d43dea682b3e409b01
-pathSuffix: Vector(3751473387, 2829804099, 4228872783, 4134047485)
+hashingPrivKey: 0x7d417a6a5e9a6a4a879aeaba11a11838764c8fa2b959c242d43dea682b3e409b
+pathSuffix: Vector(1588488367, 2659270754, 38110259, 4136336762)
 ```


### PR DESCRIPTION
The previous test vector was invalid. The `hashingPrivKey` was 33 bytes which is not valid. I assume this came about because the example code is written in scala. In the JVM it will sometimes concat a `01` byte to the end of the number when it is very large thus causing this. It looks like this invalid encoding was propagated into the rest of the code and resulted in the hmac being calculated incorrectly too. 

I was able to verify if I took the secret key `7d417a6a5e9a6a4a879aeaba11a11838764c8fa2b959c242d43dea682b3e409b` and add the `01` byte to the end when creating the HMAC I can reproduce the results in the current test vector. Using the valid key I generated the new `pathSuffix` that is correct.