### PR TITLE
docs: add description for q query parameter

### DIFF
--- a/01.md
+++ b/01.md
@@ -20,6 +20,7 @@ and presented as the following QR:
 ![A QR encoded LNURL example](https://i.imgur.com/HbB7U1K.png)
 
 Once `LNURL` is decoded:
+- `q` query parameter could be used as an identifier `k1` described in LUD02, LUD03 and so on
 - If `tag` query parameter is present, then this `LNURL` has a special meaning. Further actions will be based on `tag` parameter value.
 - Otherwise, a GET request should be executed, which must return a JSON object containing a `tag` field. Further actions will be based on `tag` field value.
 


### PR DESCRIPTION
added guideline description for query parameter `q`, so that dev would not be confused.