### PR TITLE
LUD-XX Chained LNURLs

### DIFF
--- a/24.md
+++ b/24.md
@@ -1,0 +1,8 @@
+WIP: LUD-24: LNURL chain.
+=====================================================
+
+`author: arcbtc`
+
+---
+
+Extends LUD-19, so ANY LNURL can be returned in the JSON response.

--- a/24.md
+++ b/24.md
@@ -5,4 +5,17 @@ WIP: LUD-24: LNURL chain.
 
 ---
 
-Extends LUD-19, so ANY LNURL can be returned in the JSON response.
+Extends LUD-19, so ANY LNURL can be returned in the JSON response as an `action`. Upon success, if the `action` exists it will be automatically used. 
+
+```diff
+ {
+   "tag": "withdrawRequest",
+   "callback": string,
+   "k1": string,
+   "defaultDescription": string,
+   "minWithdrawable": number,
+   "maxWithdrawable": number,
+   "balanceCheck": string,
++  "action": <string LNURL>
+ }
+```


### PR DESCRIPTION
For our Satsdice application, a user pays LNURL-pay and "might" receive a withdraw if they win. Currently they have to open a link to the LNURL-withdraw, it would be much better if the wallet automated this, so the wallet either went into the LNURL-pay workflow again (if they lost, so they can play again) or the LNURL-withdraw workflow if they won.

All LNURLs could be chained together through the response.

(I was inspired into action by BitcoinEkasi, they also have a good use case.)