### PR TITLE
 Expiry in `payRequest`

### DIFF
--- a/21.md
+++ b/21.md
@@ -1,0 +1,40 @@
+LUD-21: Expiry in `payRequest`.
+=================================
+
+`authors: rav3r, jackeveritt`
+
+---
+
+## Support for LNURL-pay expiry
+
+This allows for a `CLIENT` to pass a custom expiry property to a `SERVICE` that accepts it. This will enable clients to request time-sensitive invoices that can be used for example by escrow systems.
+
+This is completely additional/ad-hoc, so current implementations are not affected by this. Any services and clients that wish to support it do need to add some more business logic.
+
+### Service-side
+
+`SERVICE` must alter its JSON response to the first callback to include a `minExpiry`/`maxExpiry` fields, as follows:
+
+```diff
+ {
+   "callback": string,
+   "maxSendable": number,
+   "minSendable": number,
+   "metadata": string,
+   "commentAllowed": number,
++  "minExpiry": number,
++  "maxExpiry": number,
+   "tag": "payRequest"
+ }
+```
+
+The value of `minExpiry`/`maxExpiry` must be the inclusive range of seconds accepted for the `expiry` query parameter on subsequent callback.
+
+### Client-side
+
+`CLIENT` can include the expiry in its second callback to `SERVICE`:
+
+```diff
+- <callback><?|&>amount=<milliSatoshi>
++ <callback><?|&>amount=<milliSatoshi>&expiry=<seconds>
+```


### PR DESCRIPTION
Some services that use hodl/wrapped invoices don't accept very short expiry, it would be nice to request an invoice with a longer expiry.


BTW: I followed LUD-12 as my model for this proposal (by Andre Neves)