### PR TITLE
support empty domain.

### DIFF
--- a/16.md
+++ b/16.md
@@ -7,7 +7,7 @@ LUD-16: Paying to static internet identifiers.
 
 ## Paying to [internet identifiers](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1) (email-like addresses)
 
-The idea here is that a `SERVICE` can offer human-readable addresses for users or specific internal endpoints that use the format `<username>@<domainname>`, e.g. satoshi@bitcoin.org. A user can then type these on a `WALLET`. The `<username>` is limited to `a-z0-9-_.`. Please note that this is way more strict than common email addresses as it allows fewer symbols and only lowercase characters.
+The idea here is that a `SERVICE` can offer human-readable addresses for users or specific internal endpoints that use the format `<username>@<domainname>`, e.g. satoshi@bitcoin.org. A user can then type these on a `WALLET`. The `<username>` is limited to `a-z0-9-_.`, a username of `_` can be interpreted as empty domain name (<domain>) by `WALLET`'s and `SERVICE`'s. Please note that this is way more strict than common email addresses as it allows fewer symbols and only lowercase characters.
 
 Upon seeing such an address, `WALLET` makes a GET request to `https://<domain>/.well-known/lnurlp/<username>` endpoint if `domain` is clearnet or `http://<domain>/.well-known/lnurlp/<username>` if `domain` is onion. For example, if the address is `satoshi@bitcoin.org`, the request is to be made to `https://bitcoin.org/.well-known/lnurlp/satoshi`.
 


### PR DESCRIPTION
it can support empty names like nostr nip-05 convention. it looked better for someone who has their domain and they don't have multiple usernames. or a provider can use it as their address. also, it helps people on nostr to have their ln address the same as their nip-05 identifier.