### PR TITLE
feat(LUD-16): support for multiple identifiers

### DIFF
--- a/16.md
+++ b/16.md
@@ -44,6 +44,6 @@ A `SERVICE` SHOULD strip the `+<tag>` part and continue as normal and MAY add a 
 ```
 [
     "text/tag", // optional
-    string // the tag that has been passed in `<username>+<tag>`
+    content // the `<tag>` that has been passed in `<username>+<tag>`
 ]
 ```

--- a/16.md
+++ b/16.md
@@ -7,7 +7,7 @@ LUD-16: Paying to static internet identifiers.
 
 ## Paying to [internet identifiers](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1) (email-like addresses)
 
-The idea here is that a `SERVICE` can offer human-readable addresses for users or specific internal endpoints that use the format `<username>@<domainname>`, e.g. satoshi@bitcoin.org. A user can then type these on a `WALLET`. The `<username>` is limited to `a-z0-9-_.`. Please note that this is way more strict than common email addresses as it allows fewer symbols and only lowercase characters.
+The idea here is that a `SERVICE` can offer human-readable addresses for users or specific internal endpoints that use the format `<username>@<domainname>`, e.g. satoshi@bitcoin.org. A user can then type these on a `WALLET`. The `<username>` is limited to `a-z0-9-_.` (and `+` sign if it supports tags). Please note that this is way more strict than common email addresses as it allows fewer symbols and only lowercase characters.
 
 Upon seeing such an address, `WALLET` makes a GET request to `https://<domain>/.well-known/lnurlp/<username>` endpoint if `domain` is clearnet or `http://<domain>/.well-known/lnurlp/<username>` if `domain` is onion. For example, if the address is `satoshi@bitcoin.org`, the request is to be made to `https://bitcoin.org/.well-known/lnurlp/satoshi`.
 
@@ -32,3 +32,18 @@ or
 ```
 
 The `text/email` entry MUST be used if the internet identifier corresponds to an actual email address.
+
+### Tags
+
+A `SERVICE` can offer multiple identifiers resolving to the same user by using the format `<username>+<tag>@<domainname>`.
+
+Upon seeing such an address, `WALLET` makes a GET request to `https://<domain>/.well-known/lnurlp/<username>+<tag>` endpoint.
+
+A `SERVICE` SHOULD strip the `+<tag>` part and continue as normal and MAY add a `text/tag` entry to the `metadata` JSON array:
+
+```
+[
+    "text/tag", // optional
+    string // the tag that has been passed in `<username>+<tag>`
+]
+```

--- a/16.md
+++ b/16.md
@@ -7,7 +7,7 @@ LUD-16: Paying to static internet identifiers.
 
 ## Paying to [internet identifiers](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1) (email-like addresses)
 
-The idea here is that a `SERVICE` can offer human-readable addresses for users or specific internal endpoints that use the format `<username>@<domainname>`, e.g. satoshi@bitcoin.org. A user can then type these on a `WALLET`. The `<username>` is limited to `a-z0-9-_.` (and `+` sign if it supports tags). Please note that this is way more strict than common email addresses as it allows fewer symbols and only lowercase characters.
+The idea here is that a `SERVICE` can offer human-readable addresses for users or specific internal endpoints that use the format `<username>@<domainname>`, e.g. satoshi@bitcoin.org. A user can then type these on a `WALLET`. The `<username>` is limited to `a-z0-9-_.` (and `+` if the `SERVICE` supports tags). Please note that this is way more strict than common email addresses as it allows fewer symbols and only lowercase characters.
 
 Upon seeing such an address, `WALLET` makes a GET request to `https://<domain>/.well-known/lnurlp/<username>` endpoint if `domain` is clearnet or `http://<domain>/.well-known/lnurlp/<username>` if `domain` is onion. For example, if the address is `satoshi@bitcoin.org`, the request is to be made to `https://bitcoin.org/.well-known/lnurlp/satoshi`.
 


### PR DESCRIPTION
Resolves #197.

Adds support for `+<tag>` when paying to static internet identifiers.