### PR TITLE
Add LUD-23: Lightning address request specification

### DIFF
--- a/22.md
+++ b/22.md
@@ -1,0 +1,189 @@
+LUD-22: `addressRequest` base spec.
+=======================================
+
+`author: christianmoss`
+
+---
+
+## Lightning Address Sharing
+
+A service can request a user's Lightning address without requiring manual text input. This is particularly useful for games, apps, and services that need to pay users (e.g., game rewards, referral bonuses, content creator payouts) where typing an address would create friction.
+
+The service displays a QR code or triggers a URL scheme, the user's wallet prompts for permission, and upon approval sends the Lightning address to the service's callback endpoint.
+
+### User story:
+
+**Conference Gaming Example**: You're at a Bitcoin conference and want to play a kart racing game that streams sats to your wallet as you collect coins on the track.
+
+**Current friction**: You must use a keyboard to manually enter your Lightning address into a UI the game developer built. This is slow, error-prone, and breaks immersion.
+
+**With LUD-22**: You simply scan a QR code displayed on the game screen with your phone, approve the request in your wallet, and start playing immediately. The game streams sats directly to your Lightning address as you collect coins - no typing required.
+
+### Use cases:
+- Arcade/kiosk games at conferences that pay players in real-time
+- Point-of-sale systems collecting customer Lightning addresses for refunds/rewards
+- Interactive installations and experiences that reward participants
+- Game developers rewarding players without requiring account creation
+- Apps distributing payments to users
+- Services onboarding users for payouts
+- Any application needing a user's Lightning address without manual input
+
+### Server-side generation of addressRequest URL:
+
+When creating an `addressRequest` handler, `LN SERVICE` must include a `k1` query parameter consisting of randomly generated 32 bytes of data. An example is `https://yourapp.com/share-address?tag=addressRequest&k1=hex(32 bytes of random data)`.
+
+The `k1` serves two purposes:
+1. **Request matching**: Allows the service to match the callback response to the specific user/session that initiated the request
+2. **Spam prevention**: Prevents random POSTs to the callback endpoint
+
+`LN SERVICE` must maintain a cache of unused `k1` values and only accept callbacks with valid `k1` values from that cache. Used `k1` values should be removed after successful address submission to prevent replay attacks.
+
+### Server-side choice of subdomain:
+
+While not as critical as with authentication (LUD-04), `LN SERVICE` should still use clear, meaningful domain names since wallets will display the requesting domain to users for approval. For example, `rewards.yourgame.com` is clearer than `api-v2.yourgame.com`.
+
+### Wallet to service interaction flow:
+
+1. `LN WALLET` scans a QR code or receives a URL scheme intent and decodes the URL which contains:
+    - `tag` query parameter with value `addressRequest`
+    - `k1` (hex encoded 32 bytes) for request matching
+    - optional `callback` URL (if different from the base URL)
+
+2. If `callback` is not present in the initial URL, `LN WALLET` makes a GET request to the URL to retrieve details:
+
+    ```JSON
+    {
+        "tag": "addressRequest",
+        "callback": "https://yourapp.com/receive-address",
+        "k1": "hex(32 bytes of random data)",
+        "metadata": "Share your Lightning address with AwesomeGame to receive rewards"
+    }
+    ```
+
+    The `metadata` field should be a human-readable explanation of why the address is being requested.
+
+3. `LN WALLET` displays a confirmation dialog which must include:
+    - The domain name extracted from the callback URL
+    - The `metadata` text explaining the request
+    - A clear indication that the Lightning address will be shared
+    - Approve/Deny options
+
+4. Once approved by user, `LN WALLET` makes a POST request to the `callback` URL with the following JSON body:
+
+    ```JSON
+    {
+        "k1": "hex(32 bytes from request)",
+        "address": "user@wallet.com"
+    }
+    ```
+
+5. `LN SERVICE` responds with JSON:
+
+    ```JSON
+    {"status": "OK"}
+    ```
+
+    or
+
+    ```JSON
+    {"status": "ERROR", "reason": "error details..."}
+    ```
+
+### URL scheme format (same device):
+
+For same-device interactions, the URL can be formatted as:
+
+```
+lightning:addressRequest?callback=https://yourapp.com/receive&k1=hex(32 bytes)&metadata=Share%20address%20with%20AwesomeGame
+```
+
+Or services can implement deep linking to their own app:
+
+```
+yourapp://receive-address?address=user@wallet.com
+```
+
+### Encoding for QR codes:
+
+For QR code display (cross-device), the URL should be bech32-encoded following LUD-01:
+
+```
+lnurl1dp68gurn8ghj7um9wfmxjcm99e5k7... (encodes https://yourapp.com/share?tag=addressRequest&k1=...)
+```
+
+When used in QR codes, `LNURL` should be uppercase.
+
+### Security considerations:
+
+1. **Public information**: Lightning addresses are public identifiers meant to be shared. No sensitive authentication material is transmitted.
+
+2. **User consent**: Wallets MUST require explicit user approval before sharing the address. The dialog should clearly show which service is requesting the address.
+
+3. **k1 validation**: Services must validate that the `k1` in the callback matches an unused `k1` from their cache to prevent spam and replay attacks.
+
+4. **HTTPS required**: All callback URLs must use HTTPS (or http:// for Tor v2/v3 onion addresses).
+
+5. **Rate limiting**: Services should implement rate limiting on the callback endpoint to prevent abuse.
+
+6. **No authentication**: This protocol does NOT authenticate the user - it only collects their Lightning address. If authentication is needed, use LUD-04 instead.
+
+### Example implementation (JavaScript):
+
+```javascript
+// Server-side: Generate addressRequest
+const crypto = require('crypto');
+
+function generateAddressRequest(sessionId) {
+  const k1 = crypto.randomBytes(32).toString('hex');
+
+  // Store k1 with session mapping
+  sessionCache.set(k1, { sessionId, timestamp: Date.now() });
+
+  return {
+    tag: "addressRequest",
+    callback: `https://yourgame.com/api/receive-address`,
+    k1: k1,
+    metadata: "Share your Lightning address with AwesomeGame to receive in-game rewards"
+  };
+}
+
+// Server-side: Handle callback
+app.post('/api/receive-address', (req, res) => {
+  const { k1, address } = req.body;
+
+  // Validate k1
+  const session = sessionCache.get(k1);
+  if (!session) {
+    return res.json({ status: "ERROR", reason: "Invalid or expired request" });
+  }
+
+  // Validate address format (basic check)
+  if (!/^[\w\-\.]+@[\w\-\.]+\.\w+$/.test(address)) {
+    return res.json({ status: "ERROR", reason: "Invalid Lightning address format" });
+  }
+
+  // Store address with user session
+  userSessions.updateAddress(session.sessionId, address);
+
+  // Remove used k1
+  sessionCache.delete(k1);
+
+  res.json({ status: "OK" });
+});
+```
+
+### Dependencies:
+
+- **LUD-01**: Base LNURL encoding/decoding for QR code support
+- **LUD-16**: Understanding Lightning address format (`user@domain.com`)
+
+### Differences from LUD-04 (auth):
+
+Unlike authentication, this protocol:
+- Does NOT require signature generation/verification
+- Does NOT derive domain-specific keys
+- Does NOT authenticate the user's identity
+- Only collects a public Lightning address
+- Is much simpler to implement
+
+If you need authentication, use LUD-04. If you just need a payment destination, use LUD-22.

--- a/23.md
+++ b/23.md
@@ -47,11 +47,12 @@ While not as critical as with authentication (LUD-04), `LN SERVICE` should still
 1. `LN WALLET` scans a QR code or receives a URL scheme intent and decodes the URL which contains:
     - `tag` query parameter with value `addressRequest`
     - `k1` (hex encoded 32 bytes) for request matching
-    - optional `callback` URL (if different from the base URL)
+    - optional `callback` URL (if different from the initial URL)
+    - optional `description` text (must be present if `callback` is present in the initial URL)
 
 2. If `callback` is not present in the initial URL, `LN WALLET` makes a GET request to the URL to retrieve details:
 
-    ```JSON
+    ```json
     {
         "tag": "addressRequest",
         "callback": "https://yourapp.com/receive-address",
@@ -60,7 +61,13 @@ While not as critical as with authentication (LUD-04), `LN SERVICE` should still
     }
     ```
 
-    The `description` field should be a human-readable explanation of why the address is being requested.
+    `LN SERVICE` may also respond with:
+
+    ```json
+    {"status": "ERROR", "reason": "error details..."}
+    ```
+
+    `LN WALLET` MUST verify that the returned `k1` and `tag` match the values from the initial request. The `description` field MUST be a human-readable explanation of why the address is being requested.
 
 3. `LN WALLET` displays a confirmation dialog which must include:
     - The domain name extracted from the callback URL
@@ -68,21 +75,21 @@ While not as critical as with authentication (LUD-04), `LN SERVICE` should still
     - A clear indication that the Lightning address will be shared
     - Approve/Deny options
 
-4. Once approved by user, `LN WALLET` makes a GET request to the `callback` URL with the following query parameters:
+4. Once approved by user, `LN WALLET` makes a GET request to the `callback` URL using the existing query parameters and appending `k1` and `address`:
 
     ```
-    GET <callback>?k1=<hex(32 bytes from request)>&address=<user@wallet.com>
+    GET <callback_url>?<existing_query_parameters>&k1=<hex(32 bytes from request)>&address=<user@wallet.com>
     ```
 
 5. `LN SERVICE` responds with JSON:
 
-    ```JSON
+    ```json
     {"status": "OK"}
     ```
 
     or
 
-    ```JSON
+    ```json
     {"status": "ERROR", "reason": "error details..."}
     ```
 

--- a/23.md
+++ b/23.md
@@ -1,7 +1,7 @@
-LUD-22: `addressRequest` base spec.
+LUD-23: `addressRequest` base spec.
 =======================================
 
-`author: christianmoss`
+`author: Christian Moss aka Mandelduck`
 
 ---
 
@@ -17,7 +17,7 @@ The service displays a QR code or triggers a URL scheme, the user's wallet promp
 
 **Current friction**: You must use a keyboard to manually enter your Lightning address into a UI the game developer built. This is slow, error-prone, and breaks immersion.
 
-**With LUD-22**: You simply scan a QR code displayed on the game screen with your phone, approve the request in your wallet, and start playing immediately. The game streams sats directly to your Lightning address as you collect coins - no typing required.
+**With LUD-23**: You simply scan a QR code displayed on the game screen with your phone, approve the request in your wallet, and start playing immediately. The game streams sats directly to your Lightning address as you collect coins - no typing required.
 
 ### Use cases:
 - Arcade/kiosk games at conferences that pay players in real-time
@@ -34,7 +34,7 @@ When creating an `addressRequest` handler, `LN SERVICE` must include a `k1` quer
 
 The `k1` serves two purposes:
 1. **Request matching**: Allows the service to match the callback response to the specific user/session that initiated the request
-2. **Spam prevention**: Prevents random POSTs to the callback endpoint
+2. **Spam prevention**: Prevents random requests to the callback endpoint
 
 `LN SERVICE` must maintain a cache of unused `k1` values and only accept callbacks with valid `k1` values from that cache. Used `k1` values should be removed after successful address submission to prevent replay attacks.
 
@@ -56,25 +56,22 @@ While not as critical as with authentication (LUD-04), `LN SERVICE` should still
         "tag": "addressRequest",
         "callback": "https://yourapp.com/receive-address",
         "k1": "hex(32 bytes of random data)",
-        "metadata": "Share your Lightning address with AwesomeGame to receive rewards"
+        "description": "Share your Lightning address with AwesomeGame to receive rewards"
     }
     ```
 
-    The `metadata` field should be a human-readable explanation of why the address is being requested.
+    The `description` field should be a human-readable explanation of why the address is being requested.
 
 3. `LN WALLET` displays a confirmation dialog which must include:
     - The domain name extracted from the callback URL
-    - The `metadata` text explaining the request
+    - The `description` text explaining the request
     - A clear indication that the Lightning address will be shared
     - Approve/Deny options
 
-4. Once approved by user, `LN WALLET` makes a POST request to the `callback` URL with the following JSON body:
+4. Once approved by user, `LN WALLET` makes a GET request to the `callback` URL with the following query parameters:
 
-    ```JSON
-    {
-        "k1": "hex(32 bytes from request)",
-        "address": "user@wallet.com"
-    }
+    ```
+    GET <callback>?k1=<hex(32 bytes from request)>&address=<user@wallet.com>
     ```
 
 5. `LN SERVICE` responds with JSON:
@@ -94,7 +91,7 @@ While not as critical as with authentication (LUD-04), `LN SERVICE` should still
 For same-device interactions, the URL can be formatted as:
 
 ```
-lightning:addressRequest?callback=https://yourapp.com/receive&k1=hex(32 bytes)&metadata=Share%20address%20with%20AwesomeGame
+lightning:addressRequest?callback=https://yourapp.com/receive&k1=hex(32 bytes)&description=Share%20address%20with%20AwesomeGame
 ```
 
 Or services can implement deep linking to their own app:
@@ -143,13 +140,13 @@ function generateAddressRequest(sessionId) {
     tag: "addressRequest",
     callback: `https://yourgame.com/api/receive-address`,
     k1: k1,
-    metadata: "Share your Lightning address with AwesomeGame to receive in-game rewards"
+    description: "Share your Lightning address with AwesomeGame to receive in-game rewards"
   };
 }
 
 // Server-side: Handle callback
-app.post('/api/receive-address', (req, res) => {
-  const { k1, address } = req.body;
+app.get('/api/receive-address', (req, res) => {
+  const { k1, address } = req.query;
 
   // Validate k1
   const session = sessionCache.get(k1);
@@ -157,8 +154,9 @@ app.post('/api/receive-address', (req, res) => {
     return res.json({ status: "ERROR", reason: "Invalid or expired request" });
   }
 
-  // Validate address format (basic check)
-  if (!/^[\w\-\.]+@[\w\-\.]+\.\w+$/.test(address)) {
+  // Validate address format per LUD-16 (lowercase, [a-z0-9\-_.+] local part)
+  const [localPart, domain] = (address || '').split('@');
+  if (!localPart || !domain || !/^[a-z0-9\-_.+]+$/.test(localPart)) {
     return res.json({ status: "ERROR", reason: "Invalid Lightning address format" });
   }
 
@@ -186,4 +184,4 @@ Unlike authentication, this protocol:
 - Only collects a public Lightning address
 - Is much simpler to implement
 
-If you need authentication, use LUD-04. If you just need a payment destination, use LUD-22.
+If you need authentication, use LUD-04. If you just need a payment destination, use LUD-23.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ These are all the individual documents describing each small piece of protocol t
 | [19][19] | Pay link discoverable from withdraw link.                   | [Blixt][blixt], [CoinCorner][coincorner], [OBW][obw], [LifPay][lifpay], [LNbits][lnbits] |
 | [20][20] | Long payment description for pay protocol.                  | [Alby][alby], [BitBanana][bitbanana], [Blixt][blixt], [Clams][clams], [cliché][cliche], [Mash][mash], [OneKey][onekey], [Phoenix][phoenix], [Piggy][piggy] |
 | [21][21] | `verify` LNURL-pay payments                                 | [Alby][alby], [LifPay][lifpay], [Mutiny][mutiny], [Stacker.News][stacker.news], [Zaprite][zaprite] |
+| [22][22] | Request user's Lightning address                            | _implementation pending_ |
 
 [alby]: https://github.com/getAlby/lightning-browser-extension
 [bipa]: https://bipa.app
@@ -227,6 +228,7 @@ Tools for developers
 [19]: 19.md
 [20]: 20.md
 [21]: 21.md
+[22]: 22.md
 
 Dependency Tree
 ---------------

--- a/README.md
+++ b/README.md
@@ -3,140 +3,30 @@ LNURL Documents
 
 These are all the individual documents describing each small piece of protocol that can be implemented under the LNURL umbrella. Different wallets and services may implement different sets of protocols.
 
-| Number   | Description                                                 | Wallets (in alphabetical order) |
-|----------|-------------------------------------------------------------|---------|
-| [01][01] | Base LNURL encoding and decoding.                           | _all the ones listed below_ |
-| [02][02] | `channelRequest` base spec.                                 | [Balance of Satoshis][bos], [BitBanana][bitbanana], [Blixt][blixt], [Breez][breez], [cliché][cliche], [OBW][obw], [Zap Android][zap], [Zap Desktop][zap], [Zeus][zeus] |
-| [03][03] | `withdrawRequest` base spec.                                | [Alby][alby], [Balance of Satoshis][bos], [BitBanana][bitbanana], [Bitkit][bitkit], [Blixt][blixt], [BlueWallet][bluewallet], [Breez][breez], [Clams][clams], [CoinCorner][coincorner], [coinos][coinos], [Fountain][fountain], [LifPay][lifpay], [lipa wallet][lipa], [LNbits][lnbits], [LightningTipBot][ltb], [Mash][mash], [Muun][muun], [Phoenix][phoenix], [Pouch.ph][pouchph], [ShockWallet][shockwallet], [OBW][obw], [OneKey][onekey], [ThunderHub][thunderhub], [Wallet of Satoshi][wos], [Zap Android][zap], [Zap Desktop][zap], [Zap iOS][zap], [ZBD Discord][zbd], [ZBD Extension][zbd], [ZBD Telegram][zbd], [ZEBEDEE][zbd], [Zeus][zeus] |
-| [04][04] | Auth base spec.                                             | [Alby][alby], [Balance of Satoshis][bos], [BitBanana][bitbanana], [Blixt][blixt], [Breez][breez], [BlueWallet][bluewallet], [Clams][clams], [coinos][coinos], [Geyser][geyser], [LifPay][lifpay], [LNbits][lnbits], [LightningTipBot][ltb], [Phoenix][phoenix], [SeedAuth][seedauth], [SeedAuthExtension][sae], [OBW][obw], [OneKey][onekey], [Sparrow Wallet][sparrow], [ThunderHub][thunderhub], [Zap Desktop][zap], [Zeus][zeus] |
-| [05][05] | BIP32-based seed generation for auth protocol.              | [Alby][alby], [coinos][coinos], [OBW][obw], [OneKey][onekey], [Phoenix][phoenix] |
-| [06][06] | `payRequest` base spec.                                     | [Alby][alby], [Balance of Satoshis][bos], [Bare Bitcoin](barebitcoin), [Bipa][bipa], [BitBanana][bitbanana], [Blixt][blixt], [BlueWallet][bluewallet], [Breez][breez], [BTCPayServer][btcp], [Clams][clams], [cliché][cliche], [CoinCorner][coincorner], [coinos][coinos], [Electrum][electrum], [Fountain][fountain], [Galoy][galoy], [Geyser][geyser], [LifPay][lifpay], [lipa wallet][lipa], [LNbits][lnbits], [LNLink][lnlink], [LNPay.co][lnpay], [LightningTipBot][ltb], [Machankura][machankura], [Mash][mash], [OBW][obw], [OneKey][onekey], [Phoenix][phoenix], [Piggy][piggy], [Pouch.ph][pouchph], [River][river], [River Lightning][riverlightning], [ShockWallet][shockwallet], [ThunderHub][thunderhub], [Wallet of Satoshi][wos], [Zap Android][zap], [ZBD Discord][zbd], [ZBD Extension][zbd], [ZBD Telegram][zbd], [ZEBEDEE][zbd], [Zeus][zeus] |
-| [07][07] | `hostedChannelRequest` base spec.                           | [OBW][obw] |
-| [08][08] | Fast `withdrawRequest`.                                     | [cliché][cliche], [OBW][obw], [ZBD Extension][zbd] |
-| [09][09] | `successAction` field for `payRequest`.                     | [Alby][alby], [BitBanana][bitbanana], [Blixt][blixt], [BlueWallet][bluewallet], [Breez][breez], [Clams][clams], [cliché][cliche], [coinos][coinos], [Fountain][fountain], [LifPay][lifpay], [LNbits][lnbits], [LightningTipBot][ltb], [Phoenix][phoenix], [ShockWallet][shockwallet], [OBW][obw], [OneKey][onekey], [ThunderHub][thunderhub], [Wallet of Satoshi][wos], [Zap Android][zap], [ZBD Discord][zbd], [ZBD Extension][zbd], [ZBD Telegram][zbd], [ZEBEDEE][zbd], [Zeus][zeus] |
-| [10][10] | `aes` success action in `payRequest`.                       | [Alby][alby], [BitBanana][bitbanana], [Blixt][blixt], [BlueWallet][bluewallet], [Breez][breez], [Clams][clams], [cliché][cliche], [coinos][coinos], [LNbits][lnbits], [Phoenix][phoenix], [ShockWallet][shockwallet], [OBW][obw], [ThunderHub][thunderhub], [Wallet of Satoshi][wos], [Zap Android][zap], [Zeus][zeus] |
-| [11][11] | Disposable and storeable `payRequest`s.                     | [Blixt][blixt], [OBW][obw], [ZBD Extension][zbd] |
-| [12][12] | Comments in `payRequest`.                                   | [Alby][alby], [Bare Bitcoin](barebitcoin), [Bipa][bipa], [BitBanana][bitbanana], [Blixt][blixt], [BlueWallet][bluewallet], [Breez][breez], [Clams][clams], [Fountain][fountain], [LifPay][lifpay], [lipa wallet][lipa], [LNbits][lnbits], [LightningTipBot][ltb], [OneKey][onekey], [Phoenix][phoenix], [Stacker.News][stacker.news], [ThunderHub][thunderhub],  [ZBD Discord][zbd], [ZBD Extension][zbd], [ZBD Telegram][zbd], [ZEBEDEE][zbd], [Zeus][zeus] |
-| [13][13] | `signMessage`-based seed generation for auth protocol.      | [Alby][alby], [Balance of Satoshis][bos], [BitBanana][bitbanana], [Blixt][blixt], [Clams][clams], [Zeus][zeus] |
-| [14][14] | `balanceCheck`: reusable `withdrawRequest`s.                | [Alby][alby], [Blixt][blixt], [LNbits][lnbits], |
-| [15][15] | `balanceNotify`: services hurrying up the withdraw process. | [LNbits][lnbits] |
-| [16][16] | Paying to static internet identifiers.                      | [Alby][alby], [Bipa][bipa], [Balance of Satoshis][bos], [BitBanana][bitbanana], [Blixt][blixt], [BTCPayServer][btcp], [Clams][clams], [cliché][cliche], [CoinCorner][coincorner], [coinos][coinos], [Fountain][fountain], [LifPay][lifpay], [lipa wallet][lipa], [LNbits][lnbits], [LNLink][lnlink], [LightningTipBot][ltb], [Machankura][machankura], [Mash][mash], [OBW][obw], [OneKey][onekey], [Phoenix][phoenix], [Piggy][piggy], [Pouch.ph][pouchph], [River][river], [River Lightning][riverlightning], [Stacker.News][stacker.news], [Zap Android][zap], [ZBD Discord][zbd], [ZBD Extension][zbd], [ZBD Telegram][zbd], [ZEBEDEE][zbd], [Zeus][zeus] |
-| [17][17] | Scheme prefixes and raw (non bech32-encoded) URLs.          | [Alby][alby], [BitBanana][bitbanana], [Blixt][blixt], [BTCPayServer][btcp], [Clams][clams], [cliché][cliche], [CoinCorner][coincorner], [LifPay][lifpay], [lipa wallet][lipa], [Mash][mash], [Piggy][piggy], [OneKey][onekey], [ZBD Discord][zbd], [ZBD Telegram][zbd] | [Wallet of Satoshi][wos] |
-| [18][18] | Payer identity in `payRequest` protocol.                    | [Alby][alby], [BitBanana][bitbanana], [Blixt][blixt], [cliché][cliche], [OBW][obw], [Piggy][piggy], [ZBD Discord][zbd], [ZBD Telegram][zbd] |
-| [19][19] | Pay link discoverable from withdraw link.                   | [Blixt][blixt], [CoinCorner][coincorner], [OBW][obw], [LifPay][lifpay], [LNbits][lnbits] |
-| [20][20] | Long payment description for pay protocol.                  | [Alby][alby], [BitBanana][bitbanana], [Blixt][blixt], [Clams][clams], [cliché][cliche], [Mash][mash], [OneKey][onekey], [Phoenix][phoenix], [Piggy][piggy] |
-| [21][21] | `verify` LNURL-pay payments                                 | [Alby][alby], [LifPay][lifpay], [Mutiny][mutiny], [Stacker.News][stacker.news], [Zaprite][zaprite] |
-| [22][22] | Request user's Lightning address                            | _implementation pending_ |
-
-[alby]: https://github.com/getAlby/lightning-browser-extension
-[bipa]: https://bipa.app
-[barebitcoin]: https://barebitcoin.no
-[bitbanana]: https://bitbanana.app
-[bitkit]: https://bitkit.to
-[bos]: https://github.com/alexbosworth/balanceofsatoshis
-[blixt]: https://blixtwallet.github.io
-[bluewallet]: https://bluewallet.io
-[btcp]: https://btcpayserver.org
-[breez]: https://breez.technology
-[clams]: https://clams.tech
-[cliche]: https://github.com/fiatjaf/cliche
-[coincorner]: https://coincorner.com
-[coinos]: https://coinos.io
-[electrum]: https://electrum.org
-[fountain]: https://fountain.fm
-[galoy]: https://galoy.io
-[geyser]: https://geyser.fund
-[lifpay]: https://lifpay.me
-[lipa]: https://lipa.swiss
-[lnbits]: https://lnbits.com
-[lnlink]: https://lnlink.app
-[lnpay]: https://lnpay.co
-[ltb]: https://ln.tips
-[machankura]: https://8333.mobi
-[mash]: https://mash.com/consumer-experience/
-[mutiny]: https://www.mutinywallet.com
-[muun]: https://muun.com
-[OBW]: https://darthcoin.substack.com/p/obw-open-bitcoin-wallet
-[OneKey]: https://onekey.so
-[phoenix]: https://phoenix.acinq.co
-[piggy]: https://pig.gy
-[pouchlite]: https://pouch.ph/lite
-[pouchph]: https://pouch.ph
-[river]: https://river.com
-[riverlightning]: https://rls.dev
-[sae]: https://github.com/pseudozach/seedauthextension
-[sbw]: https://lightning-wallet.com
-[seedauth]: https://seedauth.etleneum.com/
-[shockwallet]: https://shockwallet.app
-[sparrow]: https://sparrowwallet.com/
-[stacker.news]: https://stacker.news/
-[thunderhub]: https://www.thunderhub.io
-[wos]: https://www.walletofsatoshi.com
-[zap]: https://zaphq.io/
-[zaprite]: https://zaprite.com
-[zbd]: https://zebedee.io/wallet
-[zeus]: https://zeusln.app
-
-Services
---------
-
-| Name                                                                                                | LUDs                                                           |
-| ----                                                                                                | ----                                                           |
-| [Azteco](https://azte.co/)                                                                          | [01][01] [03][03]                                              |
-| [Bipa](https://bipa.app)                                                                          | [01][01] [06][06] [12][12] [16][16]                                              |
-| [Bare Bitcoin](https://barebitcoin.no)                                                              | [01][01] [06][06] [12][12]
-| [BTC Origin Stories](https://btcoriginstories.com/)                                                 | [01][01] [06][06]                                              |
-| [Bitcoin Bounce](https://thndr.games/)                                                              | [01][01] [03][03] [08][08]                                     |
-| [Bitrefill](https://bitrefill.com/)                                                                 | [01][01] [02][02] [06][06] [16][16]                            |
-| [Blocktank](https://synonym.to/blocktank/)                                                          | [01][01] [02][02]                                              |
-| [Bull Bitcoin](https://www.bullbitcoin.com/)                                                        | [01][01] [03][03]                                              |
-| [CoinCorner](https://www.coincorner.com)                                                            | [01][01] [03][03] [06][06] [16][16] [17][17] [19][19]          |
-| [Fountain Podcasts](https://fountain.fm)                                                            | [01][01] [03][03] [06][06] [09][09] [12][12] [16][16]          |
-| [Galoy](https://galoy.io/)                                                                          | [01][01] [06][06]                                              |
-| [Geyser](https://geyser.fund/)                                                                      | [01][01] [04][04] [06][06]                                     |
-| [Going Dutch](https://goingdutch.pm/)                                                               | [01][01] [03][03] [06][06]                                     |
-| [HangarSix](https://www.hangarsixgaming.com/)                                                       | [01][01] [03][03]                                              |
-| [IBEXHub](https://ibexmercado.gitbook.io/ibex-hub-api/reference/api-reference)                      | [01][01] [03][03] [06][06] [16][16]                            |
-| [Infuse](https://zebedee.io/infuse/)                                                                | [01][01] [03][03]                                              |
-| [Kollider](https://kollider.xyz/)                                                                   | [01][01] [03][03] [04][04]                                     |
-| [LifPay](https://lifpay.me)                                                                         | [01][01] [03][03] [04][04] [06][06] [09][09] [12][12] [16][16] [17][17] [19][19] [21][21] |
-| [lipa wallet for business](https://lipa.swiss/for-business.html)                                    | [01][01] [03][03] [06][06]				        |
-| [LNBIG](https://lnbig.com/)                                                                         | [01][01] [02][02]                                              |
-| [ln.cash](https://ln.cash)                                                                          | [01][01] [03][03]                                              |
-| [LNMarkets](https://lnmarkets.com/)                                                                 | [01][01] [03][03] [04][04] [06][06] [16][16]                   |
-| [LNPay.co](https://lnpay.co)                                                                        | [01][01] [03][03] [06][06] [14][14]                            |
-| [LNbits.com](https://lnbits.com/)                                                                   | [01][01] [03][03] [04][04] [14][14] [15][15]                   |
-| [Lightning.Video](https://lightning.video/)                                                         | [01][01] [04][04] [06][06] [16][16]                            |
-| [Lightning Gifts](https://lightning.gifts/)                                                         | [01][01] [03][03] [06][06] [12][12]                            |
-| [LightningTipBot](https://ln.tips/)                                                                 | [01][01] [03][03] [06][06] [09][09] [12][12] [16][16] [18][18] |
-| [Lnurl-Pay Chat](https://chat.blixtwallet.com/)                                                     | [01][01] [06][06] [11][11] [12][12] [18][18]                   |
-| [Loft](https://loft.trade/)                                                                         | [01][01] [03][03] [04][04]                                     |
-| [Machankura](https://8333.mobi)                                                                     | [01][01] [06][06] [16][16]                                     |
-| [Mash](https://mash.com)                                                                            | [01][01] [03][03] [06][06] [16][16]                            |
-| [Microlancer](https://microlancer.io/)                                                              | [01][01] [03][03] [14][14]                                     |
-| [OpenNode](https://developers.opennode.com/reference/initiate-lnurl-withdrawal)                     | [01][01] [03][03]                                              |
-| [Paywall](https://paywall.link)                                                                     | [01][01] [03][03]                                              |
-| [Piggy](https://pig.gy)                                                                             | [01][01] [06][06] [16][16] [17][17] [18][18] [20][20]          |
-| [River Lightning](https://rls.dev)                                                                  | [01][01] [03][03] [06][06] [16][16] [17][17]                   |
-| [Sats4Likes](https://sats4likes.com/)                                                               | [01][01] [03][03] [14][14] [16][16]                            |
-| [Satsback.com](https://satsback.com)                                                                | [01][01] [03][03] [06][06] [16][16]                            |
-| [sms4sats](https://sms4sats.com/)                                                                   | [01][01] [03][03]                                              |
-| [SouthXchange](https://www.southxchange.com/)                                                       | [01][01] [03][03]                                              |
-| [Stacker.News](https://stacker.news/)                                                               | [01][01] [03][03] [04][04] [06][06] [12][12] [16][16]          |
-| [Surfcity Parking](https://surfcity.app/)                                                           | [01][01] [03][03]                                              |
-| [Wheel of Fortune](https://fortune.lngames.net)                                                     | [01][01] [03][03] [04][04]                                     |
-| [bridgeaddr](https://bridgeaddr.fiatjaf.com)                                                        | [01][01] [06][06] [09][09] [12][12] [16][16]                   |
-| [coinos](https://coinos.io/)                                                                        | [01][01] [03][03] [04][04] [06][06] [16][16]                   |
-| [lnshort.it](https://lnshort.it/)                                                                   | [01][01] [04][04] [06][06]                                     |
-| [lnsms.world](https://lnsms.world/)                                                                 | [01][01] [06][04] [11][11] [12][12] [16][16]                   |
-| [lnurl-pay.me](https://lnurl-pay.me)                                                                | [01][01] [06][06] [16][16]                                     |
-| [pollofeed](https://pollofeed.com)                                                                  | [01][01] [06][06] [16][16]                                     |
-| [zbd.gg](https://zbd.gg/)                                                                           | [01][01] [03][03] [06][06] [09][09] [12][12] [16][16]          |
-| [lnurlpay.com](https://lnurlpay.com/)                                                               | [01][01] [06][06] [12][12] [16][16]                            |
-| [zero fee routing](https://zerofeerouting.com/mobile-wallets/)                                      | [01][01] [02][02]                                              |
-| [strike.army](https://strike.army/)                                                                 | [01][01] [03][03] [06][06] [12][12] [16][16]                   |
-
-[rtb]: https://play.google.com/store/apps/details?id=com.pseudozach.rewardstobitcoin
+| Number   | Description                                                 |
+|----------|-------------------------------------------------------------|
+| [01][01] | Base LNURL encoding and decoding.                           |
+| [02][02] | `channelRequest` base spec.                                 |
+| [03][03] | `withdrawRequest` base spec.                                |
+| [04][04] | Auth base spec.                                             |
+| [05][05] | BIP32-based seed generation for auth protocol.              |
+| [06][06] | `payRequest` base spec.                                     |
+| [07][07] | `hostedChannelRequest` base spec.                           |
+| [08][08] | Fast `withdrawRequest`.                                     |
+| [09][09] | `successAction` field for `payRequest`.                     |
+| [10][10] | `aes` success action in `payRequest`.                       |
+| [11][11] | Disposable and storeable `payRequest`s.                     |
+| [12][12] | Comments in `payRequest`.                                   |
+| [13][13] | `signMessage`-based seed generation for auth protocol.      |
+| [14][14] | `balanceCheck`: reusable `withdrawRequest`s.                |
+| [15][15] | `balanceNotify`: services hurrying up the withdraw process. |
+| [16][16] | Paying to static internet identifiers.                      |
+| [17][17] | Scheme prefixes and raw (non bech32-encoded) URLs.          |
+| [18][18] | Payer identity in `payRequest` protocol.                    |
+| [19][19] | Pay link discoverable from withdraw link.                   |
+| [20][20] | Long payment description for pay protocol.                  |
+| [21][21] | `verify` LNURL-pay payments                                 |
+| [23][23] | Request user's Lightning address                            |
 
 Self-hosted
 -----------
@@ -229,7 +119,7 @@ Tools for developers
 [19]: 19.md
 [20]: 20.md
 [21]: 21.md
-[22]: 22.md
+[23]: 23.md
 
 Dependency Tree
 ---------------


### PR DESCRIPTION
Introduces a new protocol for services to request a user's Lightning address without manual input. Particularly useful for games, kiosks, and interactive experiences where typing creates friction.

Example use case: A kart racing game at a conference that streams sats to players as they collect coins - users simply scan a QR code instead of typing their Lightning address.