### PR TITLE
LUD-24 – pinLimit for withdrawRequest (PIN protection for NFC/Boltcard)

### DIFF
--- a/24.md
+++ b/24.md
@@ -1,4 +1,4 @@
-LUD-XX: `pinLimit` for `withdrawRequest`
+LUD-24: `pinLimit` for `withdrawRequest`
 ========================================
 
 `author: titusz` `co-author: AxelHamburch` `supersedes: PR #200` `discussion: https://github.com/lnurl/luds/issues/289`
@@ -200,8 +200,7 @@ Both follow the standard LUD-03 error format:
 
 ## Known Implementations
 
-The following open-source implementations exist prior to this LUD being assigned
-a number, demonstrating production readiness:
+The following open-source implementations demonstrate production readiness:
 
 | Project | Role | Evidence |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ These are all the individual documents describing each small piece of protocol t
 | [20][20] | Long payment description for pay protocol.                  |
 | [21][21] | `verify` LNURL-pay payments                                 |
 | [23][23] | Request user's Lightning address                            |
+| [24][24] | `pinLimit` for `withdrawRequest`                           |
 
 Self-hosted
 -----------
@@ -120,6 +121,7 @@ Tools for developers
 [20]: 20.md
 [21]: 21.md
 [23]: 23.md
+[24]: 24.md
 
 Dependency Tree
 ---------------

--- a/XX.md
+++ b/XX.md
@@ -1,7 +1,7 @@
 LUD-XX: `pinLimit` for `withdrawRequest`
 ========================================
 
-`author: titusz` `supersedes: PR #200` `discussion: https://github.com/lnurl/luds/issues/NEW`
+`author: titusz` `co-author: AxelHamburch` `supersedes: PR #200` `discussion: https://github.com/lnurl/luds/issues/289`
 
 ---
 
@@ -91,14 +91,14 @@ When a PIN is required, the `WALLET` appends it as a query parameter:
 
 **Example:**
 ```
-https://ln-example.com/withdraw?k1=abc123&pr=lnbc...&pin=123456
+https://ln-example.com/withdraw?k1=abc123&pr=lnbc...&pin=1234
 ```
 
 ---
 
 ## PIN Specification
 
-- **Length:** 4 to 8 digits (numeric only)
+- **Length:** exactly 4 digits (numeric only)
 - **Transmission:** appended to callback URL as plaintext `pin=` parameter
 - **Transport security:** HTTPS is REQUIRED for all callbacks involving `pinLimit`
 - The `WALLET` MUST display the invoice amount on the same screen as the PIN entry
@@ -116,7 +116,7 @@ https://ln-example.com/withdraw?k1=abc123&pr=lnbc...&pin=123456
    PIN before sending the callback.
 2. The `WALLET` MUST NOT auto-propose an amount solely based on `pinLimit`.
 3. The PIN entry screen MUST display the invoice amount.
-4. The `WALLET` MUST support PIN lengths of 4 to 8 digits.
+4. The `WALLET` MUST collect exactly 4 digits as the PIN.
 5. If `pinLimit` is absent, or `amount < pinLimit`, the `WALLET` proceeds per
    LUD-03 without any PIN step.
 

--- a/XX.md
+++ b/XX.md
@@ -60,26 +60,33 @@ sequenceDiagram
     Note over Terminal: decodes LNURL
 
     Terminal->>LN Service: GET decoded LNURL
-    LN Service--)Terminal: withdrawRequest JSON (with optional pinLimit)
-
-    alt pinLimit not present OR amount < pinLimit
-        Terminal->>LN Service: GET callback?k1=<k1>&pr=<invoice>
-    else amount >= pinLimit
-        LN Service--)Terminal: pinLimit threshold reached
-        Terminal->>User: display amount + PIN entry screen
-        User->>Terminal: enter 4-digit PIN
-        Terminal->>LN Service: GET callback?k1=<k1>&pr=<invoice>&pin=<pin>
-    end
 
     alt Success
-        LN Service--)Terminal: {"status": "OK"}
-        Terminal->>User: withdrawal successful
-    else Wrong PIN
-        LN Service--)Terminal: {"status": "ERROR", "reason": "Invalid PIN"}
-        Terminal->>User: notify failure (attempts remaining)
-    else Card blocked
-        LN Service--)Terminal: {"status": "ERROR", "reason": "Card blocked: too many incorrect PIN attempts"}
-        Terminal->>User: notify failure, card is blocked
+        LN Service--)Terminal: withdrawRequest JSON (with optional pinLimit)
+        Note over Terminal: creates BOLT-11 invoice
+
+        alt pinLimit not present OR amount < pinLimit
+            Terminal->>LN Service: GET callback?k1=<k1>&pr=<invoice>
+        else amount >= pinLimit
+            Terminal->>User: display amount + PIN entry screen
+            User->>Terminal: enter 4-digit PIN
+            Terminal->>LN Service: GET callback?k1=<k1>&pr=<invoice>&pin=<pin>
+        end
+
+        alt Success
+            LN Service--)Terminal: {"status": "OK"}
+            Terminal--)Terminal: awaits incoming payment
+            Terminal->>User: withdrawal successful
+        else Wrong PIN
+            LN Service--)Terminal: {"status": "ERROR", "reason": "Invalid PIN"}
+            Terminal->>User: notify failure (attempts remaining)
+        else Card blocked
+            LN Service--)Terminal: {"status": "ERROR", "reason": "Card blocked: too many incorrect PIN attempts"}
+            Terminal->>User: notify failure, card is blocked
+        end
+    else Failure
+        LN Service--)Terminal: {"status": "ERROR", "reason": string}
+        Terminal->>User: notifies of unsuccessful withdrawal
     end
 ```
 
@@ -196,4 +203,4 @@ source at the time of writing.
   and unresolved governance questions.
 - This document is a clean resubmission of that work, with updated PIN length
   range, explicit HTTPS requirement, and alignment with the governance discussion
-  in issue #NEW.
+  in issue #289.

--- a/XX.md
+++ b/XX.md
@@ -1,0 +1,186 @@
+LUD-XX: `pinLimit` for `withdrawRequest`
+========================================
+
+`author: titusz` `supersedes: PR #200` `discussion: https://github.com/lnurl/luds/issues/NEW`
+
+---
+
+## Optional PIN Authorization for `withdrawRequest`
+
+This document extends [LUD-03](03.md) by adding an optional `pinLimit` field to the
+`withdrawRequest` response. When present, it allows a `SERVICE` to require a PIN
+from the user before authorizing a withdrawal at or above a given amount.
+
+**Primary use case:** NFC payment devices (e.g. Bolt Cards) that have no battery
+and no screen, where a lost or stolen device could otherwise be drained without
+the owner's knowledge.
+
+This extension is **fully backward-compatible**: wallets that do not implement
+`pinLimit` simply ignore the field and proceed as defined in LUD-03.
+
+---
+
+## Modified `withdrawRequest` Response
+
+A `SERVICE` MAY include the `pinLimit` field in a standard LUD-03 response:
+
+```typescript
+{
+    "tag": "withdrawRequest",           // as per LUD-03
+    "callback": string,                 // as per LUD-03
+    "k1": string,                       // as per LUD-03
+    "defaultDescription": string,       // as per LUD-03
+    "minWithdrawable": number,          // as per LUD-03
+    "maxWithdrawable": number,          // as per LUD-03
+    "pinLimit": number                  // NEW (optional): millisatoshi threshold
+}
+```
+
+`pinLimit` MUST be a positive integer (in millisatoshis). If present and the
+intended withdrawal amount is **equal to or greater than** `pinLimit`, the
+`WALLET` MUST collect a PIN from the user before proceeding.
+
+---
+
+## Wallet to Service Interaction Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Wallet
+    participant LN Service
+
+    Wallet->>LN Service: GET decoded LNURL
+    LN Service--)Wallet: withdrawRequest JSON (with optional pinLimit)
+
+    alt pinLimit not present OR amount < pinLimit
+        Wallet->>User: display withdrawal dialog
+        User->>Wallet: confirm amount
+        Wallet->>LN Service: GET callback?k1=<k1>&pr=<invoice>
+    else amount >= pinLimit
+        Wallet->>User: display withdrawal dialog + PIN entry (show amount)
+        User->>Wallet: confirm amount + enter PIN
+        Wallet->>LN Service: GET callback?k1=<k1>&pr=<invoice>&pin=<pin>
+    end
+
+    alt Success
+        LN Service--)Wallet: {"status": "OK"}
+        Wallet->>User: withdrawal successful
+    else Wrong PIN
+        LN Service--)Wallet: {"status": "ERROR", "reason": "Invalid PIN"}
+        Wallet->>User: notify failure
+    else Link invalidated
+        LN Service--)Wallet: {"status": "ERROR", "reason": "Link invalidated"}
+        Wallet->>User: notify failure
+    end
+```
+
+---
+
+## Modified Callback Request
+
+When a PIN is required, the `WALLET` appends it as a query parameter:
+
+```
+<callback>
+  <?|&>
+  k1=<k1>
+  &pr=<lightning invoice>
+  &pin=<pin>
+```
+
+**Example:**
+```
+https://ln-example.com/withdraw?k1=abc123&pr=lnbc...&pin=123456
+```
+
+---
+
+## PIN Specification
+
+- **Length:** 4 to 8 digits (numeric only)
+- **Transmission:** appended to callback URL as plaintext `pin=` parameter
+- **Transport security:** HTTPS is REQUIRED for all callbacks involving `pinLimit`
+- The `WALLET` MUST display the invoice amount on the same screen as the PIN entry
+
+> **Note on PIN visibility:** The PIN is visible to the point-of-sale device
+> during entry. This is an accepted trade-off for the NFC use case. Transport
+> encryption (HTTPS/TLS) protects against network interception. Services MAY
+> additionally hash PINs at rest.
+
+---
+
+## Wallet Implementation Requirements
+
+1. If `pinLimit` is present and `amount >= pinLimit`, the `WALLET` MUST collect a
+   PIN before sending the callback.
+2. The `WALLET` MUST NOT auto-propose an amount solely based on `pinLimit`.
+3. The PIN entry screen MUST display the invoice amount.
+4. The `WALLET` MUST support PIN lengths of 4 to 8 digits.
+5. If `pinLimit` is absent, or `amount < pinLimit`, the `WALLET` proceeds per
+   LUD-03 without any PIN step.
+
+---
+
+## Service Implementation Requirements
+
+1. If `pinLimit` is present in the response, the `SERVICE` MUST validate the
+   `pin` query parameter for withdrawals at or above the threshold.
+2. The `SERVICE` MUST invalidate the LNURL link after **3 consecutive PIN
+   failures** to prevent brute-force attacks.
+3. This document makes no assumption about whether PINs are static or one-time
+   passwords (OTPs) — that is a service-level implementation decision.
+4. HTTPS is REQUIRED on all callback URLs that use `pinLimit`.
+
+---
+
+## Error Responses
+
+| Condition | `reason` string |
+|---|---|
+| Wrong PIN (attempts remaining) | `"Invalid PIN"` |
+| Link invalidated after 3 failures | `"Link invalidated"` |
+
+Both follow the standard LUD-03 error format:
+```json
+{"status": "ERROR", "reason": "..."}
+```
+
+---
+
+## Security Considerations
+
+- **Lost/stolen NFC device:** `pinLimit` limits exposure to low-value taps only.
+  High-value withdrawals require PIN confirmation.
+- **PIN at PoS:** The PIN is seen by the merchant terminal. This is acceptable
+  in the same way a card PIN at a payment terminal is accepted in traditional
+  payments.
+- **Brute force:** The mandatory 3-attempt limit and link invalidation prevent
+  automated attacks.
+- **Replay:** Inherits LUD-03 replay protection via ephemeral `k1`.
+
+---
+
+## Known Implementations
+
+The following implementations exist prior to this LUD being assigned a number,
+demonstrating production readiness:
+
+| Project | Role | Notes |
+|---|---|---|
+| [Bolt Card Wallet](https://github.com/boltcard/boltcard-wallet) | Wallet | Full support |
+| [Bolt Card PoS](https://github.com/boltcard/boltcard-pos) | Wallet/PoS | Full support |
+| [SwissBitcoinPay boltcard-tools](https://github.com/SwissBitcoinPay/boltcard-tools-terminal) | Service | Full support |
+| [LifPay](https://lifpay.me) | Service | Supports 4–12 digit PINs |
+
+---
+
+## Prior Art
+
+- **PR #200** (`LUD-21: pinLimit for withdrawRequest`, Feb 2023): Original proposal
+  by @titusz. Technically sound, received 2 approvals, implemented in production.
+  Not merged due to number conflict (LUD-21 was assigned to the `verify` spec)
+  and unresolved governance questions.
+- This document is a clean resubmission of that work, with updated PIN length
+  range, explicit HTTPS requirement, and alignment with the governance discussion
+  in issue #NEW.

--- a/XX.md
+++ b/XX.md
@@ -47,6 +47,25 @@ intended withdrawal amount is **equal to or greater than** `pinLimit`, the
 
 ---
 
+## Interaction Steps
+
+1. User taps an NFC device (e.g. Bolt Card) to a `TERMINAL`. The `TERMINAL` reads
+   and decodes the LNURL.
+2. `TERMINAL` makes a GET request to `LN SERVICE` using the decoded LNURL.
+3. `TERMINAL` receives a JSON response from `LN SERVICE` as defined in LUD-03,
+   optionally extended with `pinLimit`.
+4. `TERMINAL` creates a BOLT-11 invoice for the intended withdrawal amount.
+5. If `pinLimit` is **not present**, or the amount is **below** `pinLimit`:
+   `TERMINAL` sends a GET to `LN SERVICE` with `k1` and `pr` as per LUD-03.
+6. If the amount is **equal to or greater than** `pinLimit`:
+   `TERMINAL` displays the invoice amount and prompts the user for a 4-digit PIN.
+   Once entered, `TERMINAL` sends a GET to `LN SERVICE` with `k1`, `pr`, and `pin`.
+7. `LN SERVICE` validates the PIN (if required) and responds with
+   `{"status": "OK"}` or `{"status": "ERROR", "reason": "..."}`.
+8. On success, `TERMINAL` awaits the incoming Lightning payment.
+
+---
+
 ## Wallet to Service Interaction Flow
 
 ```mermaid
@@ -89,25 +108,6 @@ sequenceDiagram
         Terminal->>User: notifies of unsuccessful withdrawal
     end
 ```
-
----
-
-## Interaction Steps
-
-1. User taps an NFC device (e.g. Bolt Card) to a `TERMINAL`. The `TERMINAL` reads
-   and decodes the LNURL.
-2. `TERMINAL` makes a GET request to `LN SERVICE` using the decoded LNURL.
-3. `TERMINAL` receives a JSON response from `LN SERVICE` as defined in LUD-03,
-   optionally extended with `pinLimit`.
-4. `TERMINAL` creates a BOLT-11 invoice for the intended withdrawal amount.
-5. If `pinLimit` is **not present**, or the amount is **below** `pinLimit`:
-   `TERMINAL` sends a GET to `LN SERVICE` with `k1` and `pr` as per LUD-03.
-6. If the amount is **equal to or greater than** `pinLimit`:
-   `TERMINAL` displays the invoice amount and prompts the user for a 4-digit PIN.
-   Once entered, `TERMINAL` sends a GET to `LN SERVICE` with `k1`, `pr`, and `pin`.
-7. `LN SERVICE` validates the PIN (if required) and responds with
-   `{"status": "OK"}` or `{"status": "ERROR", "reason": "..."}`.
-8. On success, `TERMINAL` awaits the incoming Lightning payment.
 
 ---
 

--- a/XX.md
+++ b/XX.md
@@ -147,7 +147,7 @@ https://ln-example.com/withdraw?k1=abc123&pr=lnbc...&pin=1234
 | Condition | `reason` string |
 |---|---|
 | Wrong PIN (attempts remaining) | `"Invalid PIN"` |
-| Link invalidated after 3 failures | `"Link invalidated"` |
+| Link invalidated after 3 failures | `"Card blocked: too many incorrect PIN attempts"` |
 
 Both follow the standard LUD-03 error format:
 ```json

--- a/XX.md
+++ b/XX.md
@@ -15,8 +15,13 @@ from the user before authorizing a withdrawal at or above a given amount.
 and no screen, where a lost or stolen device could otherwise be drained without
 the owner's knowledge.
 
-This extension is **fully backward-compatible**: wallets that do not implement
-`pinLimit` simply ignore the field and proceed as defined in LUD-03.
+**For services:** `pinLimit` is optional to deploy. Services that do not set it
+behave exactly as defined in LUD-03.
+
+**For wallets:** If `pinLimit` is present in the response and `amount >= pinLimit`,
+PIN entry is **mandatory**. A wallet or terminal that does not support PIN entry
+will send the callback without a `pin` parameter — the `SERVICE` MUST reject
+that request. There is no fallback or bypass once the threshold is met.
 
 ---
 
@@ -124,8 +129,11 @@ https://ln-example.com/withdraw?k1=abc123&pr=lnbc...&pin=1234
 
 ## Service Implementation Requirements
 
-1. If `pinLimit` is present in the response, the `SERVICE` MUST validate the
-   `pin` query parameter for withdrawals at or above the threshold.
+1. If `pinLimit` is present in the response and the withdrawal amount is at or
+   above the threshold, the `SERVICE` MUST require the `pin` query parameter.
+   If `pin` is absent or invalid, the `SERVICE` MUST reject the request with
+   an error response. There is no fallback — terminals without PIN support will
+   be rejected.
 2. The `SERVICE` MUST invalidate the LNURL link after **3 consecutive PIN
    failures** to prevent brute-force attacks.
 3. This document makes no assumption about whether PINs are static or one-time

--- a/XX.md
+++ b/XX.md
@@ -171,15 +171,17 @@ Both follow the standard LUD-03 error format:
 
 ## Known Implementations
 
-The following implementations exist prior to this LUD being assigned a number,
-demonstrating production readiness:
+The following open-source implementations exist prior to this LUD being assigned
+a number, demonstrating production readiness:
 
-| Project | Role | Notes |
+| Project | Role | Evidence |
 |---|---|---|
-| [Bolt Card Wallet](https://github.com/boltcard/boltcard-wallet) | Wallet | Full support |
-| [Bolt Card PoS](https://github.com/boltcard/boltcard-pos) | Wallet/PoS | Full support |
-| [SwissBitcoinPay boltcard-tools](https://github.com/SwissBitcoinPay/boltcard-tools-terminal) | Service | Full support |
-| [LifPay](https://lifpay.me) | Service | Supports 4–12 digit PINs |
+| [boltcard-tools-terminal](https://github.com/SwissBitcoinPay/boltcard-tools-terminal) | PoS terminal | [PR #33](https://github.com/SwissBitcoinPay/boltcard-tools-terminal/pull/33) merged 2024-05-26: PIN pad appears when `amount >= pinLimit`, sends 4-digit PIN |
+| [boltcard-lndhub](https://github.com/boltcard/boltcard-lndhub) | Service/backend | Release v0.2.0 (2023-08-06): "PIN feature added" |
+
+Additional projects are reported to implement PIN support in PR #200 discussion
+(boltcard-wallet, LifPay) but could not be independently verified via public
+source at the time of writing.
 
 ---
 

--- a/XX.md
+++ b/XX.md
@@ -52,31 +52,34 @@ intended withdrawal amount is **equal to or greater than** `pinLimit`, the
 ```mermaid
 sequenceDiagram
     actor User
-    participant Wallet
+    participant Terminal as Terminal (Wallet)
     participant LN Service
 
-    Wallet->>LN Service: GET decoded LNURL
-    LN Service--)Wallet: withdrawRequest JSON (with optional pinLimit)
+    User->>Terminal: taps NFC device (e.g. Bolt Card)
+    Note over Terminal: reads LNURL from NFC
+    Note over Terminal: decodes LNURL
+
+    Terminal->>LN Service: GET decoded LNURL
+    LN Service--)Terminal: withdrawRequest JSON (with optional pinLimit)
 
     alt pinLimit not present OR amount < pinLimit
-        Wallet->>User: display withdrawal dialog
-        User->>Wallet: confirm amount
-        Wallet->>LN Service: GET callback?k1=<k1>&pr=<invoice>
+        Terminal->>LN Service: GET callback?k1=<k1>&pr=<invoice>
     else amount >= pinLimit
-        Wallet->>User: display withdrawal dialog + PIN entry (show amount)
-        User->>Wallet: confirm amount + enter PIN
-        Wallet->>LN Service: GET callback?k1=<k1>&pr=<invoice>&pin=<pin>
+        LN Service--)Terminal: pinLimit threshold reached
+        Terminal->>User: display amount + PIN entry screen
+        User->>Terminal: enter 4-digit PIN
+        Terminal->>LN Service: GET callback?k1=<k1>&pr=<invoice>&pin=<pin>
     end
 
     alt Success
-        LN Service--)Wallet: {"status": "OK"}
-        Wallet->>User: withdrawal successful
+        LN Service--)Terminal: {"status": "OK"}
+        Terminal->>User: withdrawal successful
     else Wrong PIN
-        LN Service--)Wallet: {"status": "ERROR", "reason": "Invalid PIN"}
-        Wallet->>User: notify failure
-    else Link invalidated
-        LN Service--)Wallet: {"status": "ERROR", "reason": "Card blocked: too many incorrect PIN attempts"}
-        Wallet->>User: notify failure, card is blocked
+        LN Service--)Terminal: {"status": "ERROR", "reason": "Invalid PIN"}
+        Terminal->>User: notify failure (attempts remaining)
+    else Card blocked
+        LN Service--)Terminal: {"status": "ERROR", "reason": "Card blocked: too many incorrect PIN attempts"}
+        Terminal->>User: notify failure, card is blocked
     end
 ```
 

--- a/XX.md
+++ b/XX.md
@@ -92,6 +92,25 @@ sequenceDiagram
 
 ---
 
+## Interaction Steps
+
+1. User taps an NFC device (e.g. Bolt Card) to a `TERMINAL`. The `TERMINAL` reads
+   and decodes the LNURL.
+2. `TERMINAL` makes a GET request to `LN SERVICE` using the decoded LNURL.
+3. `TERMINAL` receives a JSON response from `LN SERVICE` as defined in LUD-03,
+   optionally extended with `pinLimit`.
+4. `TERMINAL` creates a BOLT-11 invoice for the intended withdrawal amount.
+5. If `pinLimit` is **not present**, or the amount is **below** `pinLimit`:
+   `TERMINAL` sends a GET to `LN SERVICE` with `k1` and `pr` as per LUD-03.
+6. If the amount is **equal to or greater than** `pinLimit`:
+   `TERMINAL` displays the invoice amount and prompts the user for a 4-digit PIN.
+   Once entered, `TERMINAL` sends a GET to `LN SERVICE` with `k1`, `pr`, and `pin`.
+7. `LN SERVICE` validates the PIN (if required) and responds with
+   `{"status": "OK"}` or `{"status": "ERROR", "reason": "..."}`.
+8. On success, `TERMINAL` awaits the incoming Lightning payment.
+
+---
+
 ## Modified Callback Request
 
 When a PIN is required, the `WALLET` appends it as a query parameter:

--- a/XX.md
+++ b/XX.md
@@ -75,8 +75,8 @@ sequenceDiagram
         LN Service--)Wallet: {"status": "ERROR", "reason": "Invalid PIN"}
         Wallet->>User: notify failure
     else Link invalidated
-        LN Service--)Wallet: {"status": "ERROR", "reason": "Link invalidated"}
-        Wallet->>User: notify failure
+        LN Service--)Wallet: {"status": "ERROR", "reason": "Card blocked: too many incorrect PIN attempts"}
+        Wallet->>User: notify failure, card is blocked
     end
 ```
 


### PR DESCRIPTION
## Summary

Clean resubmission of PR #200 (`pinLimit` for `withdrawRequest`), open since
February 2023 without being merged.

Supersedes #200. Related to governance discussion: #289.

Spec file: [`24.md`](https://github.com/AxelHamburch/luds/blob/draft/pinlimit-withdrawrequest/24.md)

## What this adds

An optional `pinLimit` field to the `withdrawRequest` response (LUD-03 extension).
When present and the withdrawal amount meets or exceeds the threshold, the wallet
must collect a 4-digit numeric PIN before sending the callback. If the PIN is
absent or wrong, the SERVICE MUST reject the request — there is no fallback.

**Assigned as LUD-24.**

## Why now

- PR #200 has 2 approvals and is already running in production
- LUD-24 is now the assigned, unreserved LUD number
- The proposal has a verified terminal and service implementation

## Changes vs PR #200

| | PR #200 | This PR |
|---|---|---|
| LUD number | LUD-21 (conflict) | LUD-24 |
| HTTPS | implicit | explicit MUST |
| Brute-force protection | SHOULD | MUST |
| Service rejection if PIN missing | unclear | explicit MUST |
| Mermaid diagram | none | added (aligned with LUD-03) |
| Prior art reference | none | PR #200 cited |

## Known implementations (verified)

| Project | Evidence |
|---|---|
| [SwissBitcoinPay/boltcard-tools-terminal](https://github.com/SwissBitcoinPay/boltcard-tools-terminal) | [PR #33](https://github.com/SwissBitcoinPay/boltcard-tools-terminal/pull/33) merged 2024-05-26 |
| [boltcard/boltcard-lndhub](https://github.com/boltcard/boltcard-lndhub) | Release v0.2.0 (2023-08-06): "PIN feature added" |