### PR TITLE
Improve LUD-04: add linkingKey derivation summary and early references

### DIFF
--- a/04.md
+++ b/04.md
@@ -9,6 +9,8 @@ LUD-04: `auth` base spec.
 
 A special `linkingKey` can be used to login user to a service or authorise sensitive actions. This preferably should be done without compromising user identity, so plain LN node key can not be used here. Instead of asking for user credentials, a service could display a "login" QR code which contains a specialized `LNURL`.
 
+The `linkingKey` is a domain-specific key derived from the user's wallet seed. For details on how it is derived, see [LUD-05](05.md) (BIP32-based) and [LUD-13](13.md) (signMessage-based).
+
 
 ### Server-side generation of auth URL and signature verification:
 
@@ -34,12 +36,12 @@ Later, once `LN SERVICE` receives a call at the specified `LNURL-auth` handler, 
 2. `LN WALLET` displays a "Login" dialog which must include a domain name extracted from `LNURL` query string and `action` enum translated into human readable text if `action` query parameter was present.
 3. Once accepted by user, `LN WALLET` signs `k1` on `secp256k1` using `linkingPrivKey` and DER-encodes the signature. `LN WALLET` Then issues a GET to `LN SERVICE` using `<LNURL_hostname_and_path>?<LNURL_existing_query_parameters>&sig=<hex(sign(hexToBytes(k1), linkingPrivKey))>&key=<hex(linkingKey)>`
 4. `LN SERVICE` responds with the following JSON once client signature is verified:
-    ```JSON
+    ```json
     {"status": "OK"}
     ```
     or
 
-    ```JSON
+    ```json
     {"status": "ERROR", "reason": "error details..."}
     ```
 
@@ -55,7 +57,19 @@ Later, once `LN SERVICE` receives a call at the specified `LNURL-auth` handler, 
 
 However, the second goal is not reachable in practice because there exist different formats of seeds which can't be transferred across all existing wallets. As such, a practical approach is to have recommended ways to derive `linkingKey` for different wallet types.
 
-Please refer to the following LUDs for more details:  
+### BIP32-based derivation
+
+For BIP32-compatible wallets, the derivation works as follows:
+
+1. A private `hashingKey` is derived from the wallet master key using the `m/138'/0` path.
+2. The `LN SERVICE` full domain name (FQDN with trailing dot omitted) is hashed using `HMAC-SHA256(hashingKey, domain)`.
+3. The first 16 bytes of the resulting hash are converted into four 32-bit unsigned integers, which are used to derive the service-specific `linkingKey` at path `m/138'/<long1>/<long2>/<long3>/<long4>`.
+
+### signMessage-based derivation
+
+For wallets that cannot access the master private key, a different scheme is used based on `signMessage` with a domain-specific message. See [LUD-13](13.md) for the full specification.
+
+Please refer to the following LUDs for complete details:  
 [LUD-05](05.md): BIP32-based seed generation for auth protocol.  
 [LUD-13](13.md): signMessage-based seed generation for auth protocol. 
 


### PR DESCRIPTION
Fixes #262

## Changes

- **Add early reference to LUD-05 and LUD-13** in the intro paragraph so readers immediately know where to find the derivation details
- **Add a BIP32-based derivation summary** — the three-step process (m/138'/0 hashingKey → HMAC-SHA256 with domain → m/138'/<long1>/<long2>/<long3>/<long4>) that was present in the legacy doc but missing from the current LUD
- **Add signMessage-based derivation summary** with a link to LUD-13 for wallets that cannot access the master private key
- **Fix JSON code block language tags** to lowercase (json) for consistency with other LUDs

## Why

The legacy lnurl-auth.md had detailed derivation logic (including a Scala code example) that got lost when the spec was split into LUD-04, LUD-05, and LUD-13. The current LUD-04 just says "go read these other docs" without giving any conceptual context. This adds back the high-level derivation overview so readers can understand the flow before diving into the full specs.