### PR TITLE
LUD-XX: Currencies

### DIFF
--- a/24.md
+++ b/24.md
@@ -76,4 +76,4 @@ If there is a `currency` record, `WALLET` should display a modified interface:
 
 ## 5. User interface for reviewing & confirming the exchange rate
 
-- `WALLET` must display a confirmation screen so that the user can review and confirm the invoice amount.
+`WALLET` must display a confirmation screen so that the user can review and confirm the invoice amount.

--- a/24.md
+++ b/24.md
@@ -17,7 +17,7 @@ This document describes an extension to the [payRequest](https://github.com/lnur
 
 The main features provided by this extension are:
 - `SERVICE` **MAY** provide `WALLET` with a list of supported currencies.
-- `WALLET` **MAY** allow user to pay an amount denominated in a supported currency.
+- `WALLET` **MAY** allow user to request an invoice for an amount denominated in a supported currency in place of millisats.
 
 
 ### 1. `currencies` array in payRequest details

--- a/24.md
+++ b/24.md
@@ -1,0 +1,79 @@
+LUD-24: `currencies` base spec.
+=======================================
+
+`author: ethanrose` `author: lsunsi` `author: lorenzolfm` `author: jklein24`
+
+---
+
+## Support for LNURL-pay currencies
+
+This document describes an extension to the [payRequest](https://github.com/lnurl/luds/blob/luds/06.md) base specification that allows the `WALLET` to send money to a `SERVICE` while denominating the amount in a different currency. The features proposed enable many use cases including:
+
+- Bitcoin-settled cash remittances
+- Merchant bitcoin acceptance
+- Lightning address aliases for bank & mobile money accounts
+- Cross-border payroll
+
+
+The main features provided by this extension are:
+- `SERVICE` **MUST** inform `WALLET` what currencies it supports
+- `WALLET` **MAY** request an invoice with an amount denominated in one of the currencies
+
+
+## 1. `currencies` array in payRequest details
+
+`SERVICE` must alter its JSON response to the first request to include a `currencies` field, as follows:
+
+```diff
+{
+  "tag": "payRequest",
+  "callback": string,
+  "maxSendable": number,
+  "minSendable": number,
+  "metadata": string,
++ "currencies": [
++   {
++     "code": "PHP",
++     "name": "Philippine Pesos",
++     "symbol": "₱",
++     "decimals": 2,
++     "minSendable": 1,
++     "maxSendable": 50000,
++     "multiplier": 64501 // (optional)
++   }
++ ]
+}
+```
+
+- The inclusion of the `currencies` field indicates the support of this extension
+- The `multiplier` may be included for informational purposes, not a guaranteed rate
+- The `code` of a `currency` must be unique
+- The order of the `currencies` may be interpreted by the `WALLET` as the receiving user preference for a currency
+
+
+## 2. Wallet interface
+
+If there is a `currency` record, `WALLET` should display a modified interface:
+- Display currency symbol and code
+- If there are multiple currency options, allow user to select/change currencies
+- Validate "decimals" count for user amount input
+
+
+## 3. Including `currency` in callback parameters
+
+```diff
+- <callback><?|&>amount=<number>
++ <callback><?|&>currency=PHP&amount=<numberInSmallestUnit>
+```
+
+- Amount must be in SMALLEST UNIT INTEGER (wallet should use `decimals` value to modify amount)
+- If `currency` param is omitted, the `amount` will be interpreted as millisatoshis (base spec)
+
+
+## 4. Service processing
+
+`SERVICE` response is unchanged. The invoice amount will be in millisats, but the expiry may be short duraction if the service opts to lock-in a rate for auto-conversion. Auto-conversion is `SERVICE` recipient's preference, not relevant to `WALLET` sender.
+
+## 5. User interface for reviewing & confirming the exchange rate
+
+- `WALLET` must display a confirmation screen so that the user can review and confirm the invoice amount.

--- a/24.md
+++ b/24.md
@@ -72,7 +72,9 @@ If there is a `currency` record, `WALLET` should display a modified interface:
 
 ### 4. Service processing
 
-`SERVICE` response is unchanged. The invoice amount will be in millisats, but the expiry may be short duraction if the service opts to lock-in a rate for auto-conversion. Auto-conversion is `SERVICE` recipient's preference, not relevant to `WALLET` sender.
+`SERVICE` response is unchanged.
+
+`SERVICE` may optionally lock-in a rate and auto-convert to the specified currency, but that is a `SERVICE` / recipient decision, not relevant to the `WALLET` / sender.
 
 ### 5. User interface for reviewing & confirming the exchange rate
 

--- a/24.md
+++ b/24.md
@@ -20,7 +20,7 @@ The main features provided by this extension are:
 - `WALLET` **MAY** request an invoice with an amount denominated in one of the currencies
 
 
-## 1. `currencies` array in payRequest details
+### 1. `currencies` array in payRequest details
 
 `SERVICE` must alter its JSON response to the first request to include a `currencies` field, as follows:
 
@@ -51,7 +51,7 @@ The main features provided by this extension are:
 - The order of the `currencies` may be interpreted by the `WALLET` as the receiving user preference for a currency
 
 
-## 2. Wallet interface
+### 2. Wallet interface
 
 If there is a `currency` record, `WALLET` should display a modified interface:
 - Display currency symbol and code
@@ -59,7 +59,7 @@ If there is a `currency` record, `WALLET` should display a modified interface:
 - Validate "decimals" count for user amount input
 
 
-## 3. Including `currency` in callback parameters
+### 3. Including `currency` in callback parameters
 
 ```diff
 - <callback><?|&>amount=<number>
@@ -70,10 +70,10 @@ If there is a `currency` record, `WALLET` should display a modified interface:
 - If `currency` param is omitted, the `amount` will be interpreted as millisatoshis (base spec)
 
 
-## 4. Service processing
+### 4. Service processing
 
 `SERVICE` response is unchanged. The invoice amount will be in millisats, but the expiry may be short duraction if the service opts to lock-in a rate for auto-conversion. Auto-conversion is `SERVICE` recipient's preference, not relevant to `WALLET` sender.
 
-## 5. User interface for reviewing & confirming the exchange rate
+### 5. User interface for reviewing & confirming the exchange rate
 
 `WALLET` must display a confirmation screen so that the user can review and confirm the invoice amount.

--- a/24.md
+++ b/24.md
@@ -16,8 +16,8 @@ This document describes an extension to the [payRequest](https://github.com/lnur
 
 
 The main features provided by this extension are:
-- `SERVICE` **MUST** inform `WALLET` what currencies it supports
-- `WALLET` **MAY** request an invoice with an amount denominated in one of the currencies
+- `SERVICE` **MAY** provide `WALLET` with a list of supported currencies.
+- `WALLET` **MAY** allow user to pay an amount denominated in a supported currency.
 
 
 ### 1. `currencies` array in payRequest details


### PR DESCRIPTION
My initial PR (Pouch.ph implementation) was https://github.com/lnurl/luds/pull/207

This new proposal is an update from my original PR, in order to be compatible with:

- Bipa implementation: https://github.com/lnurl/luds/pull/251

- LightSpark implementation: https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md

However, I have left out some of their implementation details in the spirit of keeping the spec as barebones as possible. 

Namely:

- **Convert/convertible**: At Pouch, currency conversion is a recipient config, not a sender's payment flow decision. If some services wish to give the sender power over the recipient's settlement currency by sending a param, it should be a follow-on LUD.

- **Final Response Multiplier & Fee** This doesn't provide info that the wallet can't already derive (multiplier) or should trust (fee). If services are using this, it should be a follow-on LUD.